### PR TITLE
Output master IP.

### DIFF
--- a/phase1/gce/lib/gce.jsonnet
+++ b/phase1/gce/lib/gce.jsonnet
@@ -30,6 +30,11 @@ function(cfg)
     },
   });
   {
+    output: {
+      [names.master_ip]: {
+        value: "${google_compute_address.%(master_ip)s.address}" % names,
+      },
+    },
     provider: {
       google: {
         credentials: "${file(\"account.json\")}",


### PR DESCRIPTION
This change makes terraform apply print the master IP at the end of the output.

cc @mikedanese 