### PR TITLE
Azure: Phase1 Implementation + necessary Phase2 Changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN apt-get update && apt-get -y upgrade && \
 RUN npm install -g azure-cli
 
 # Install Jsonnet
-ENV JSONNET_GIT_TAG v0.8.8
+# ENV JSONNET_GIT_TAG v0.8.8
+#     (too old - std.manifestJson is missing)
+ENV JSONNET_GIT_TAG master
 RUN cd /tmp \
     && git clone https://github.com/google/jsonnet \
     && cd jsonnet \

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ SHELL=/bin/bash
 
 .PHONY: config echo-config
 
+IMAGE_NAME?=kubernetes-anywhere
+IMAGE_VERSION?=v0.0.1
 
 # sorry windows and non amd64
 UNAME_S := $(shell uname -s)
@@ -51,10 +53,21 @@ deploy destroy: .config.json
 do:
 	( cd "phase1/$$(jq -r '.phase1.cloud_provider' .config.json)"; ./do $(WHAT) )
 
+docker-build:
+	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
+
+docker-run: docker-build
+	docker run -it --net=host $(IMAGE_NAME):$(IMAGE_VERSION) /bin/bash
+
+docker-dev: docker-build
+	docker run -it --net=host -v `pwd`:/root/kubernetes-anywhere $(IMAGE_NAME):$(IMAGE_VERSION) /bin/bash
+
+
 clean:
 	rm -rf .tmp
 	rm -rf phase3/.tmp
-	rm -rf phase1/gce/out
+	rm -rf phase1/gce/.tmp
+	rm -rf phase1/azure/.tmp
 
 fmt:
 	for f in $$(find . -name '*.jsonnet'); do jsonnet fmt -i -n 2 $${f}; done;

--- a/phase1/Kconfig
+++ b/phase1/Kconfig
@@ -20,10 +20,14 @@ menuconfig phase1.cloud_provider
 	help
 	  The cloud provider you would like to deploy to.
 
-	  Valid options are (gce).
+	  Valid options are (gce, azure).
 
 if phase1.cloud_provider = "gce"
 	source "phase1/gce/Kconfig"
+endif
+
+if phase1.cloud_provider = "azure"
+	source "phase1/azure/Kconfig"
 endif
 
 endmenu

--- a/phase1/azure/Kconfig
+++ b/phase1/azure/Kconfig
@@ -1,0 +1,76 @@
+menu "Azure configuration"
+
+config phase1.azure.image_publisher
+	string "Base Virtual Machine OS Image"
+	default "canonical"
+	help
+		The publisher of the base image used for the VirtualMachines.
+config phase1.azure.image_offer
+	string "Base Virtual Machine OS Image"
+	default "ubuntuserver"
+	help
+		The offer of the base image used for the VirtualMachines.
+config phase1.azure.image_sku
+	string "Base Virtual Machine OS Image"
+	default "16.04.0-LTS"
+	help
+		The sku of the base image used for the VirtualMachines.
+config phase1.azure.image_version
+	string "Base Virtual Machine OS Image"
+	default "latest"
+	help
+		The version of the base image used for the VirtualMachines.
+
+config phase1.azure.master_vm_size
+	string "Virtual Machine Size (Master)"
+	default "Standard_D1_v2"
+	help
+		The size of VirtualMachine to deploy.
+
+config phase1.azure.node_vm_size
+	string "Virtual Machine Size (Node)"
+	default "Standard_D1_v2"
+	help
+		The size of VirtualMachine to deploy.
+
+config phase1.azure.master_private_ip
+	string "Private IP address of Master"
+	default "10.0.1.4"
+	help
+		The private ip address of master
+
+config phase1.azure.location
+	string "Resource Location"
+	default "westus"
+	help
+		The Azure location to use.
+
+config phase1.azure.admin_username
+	string "Virtual Machine Admin Username"
+	default "kube"
+
+config phase1.azure.admin_password
+	string "Virtual Machine Admin Password"
+	default "AzureKubernet3s!"
+
+config phase1.azure.tenant_id
+	string "ActiveDirectory ServicePrincipal ClientSecret"
+	help
+		The ClientSecret of the Service Account to be used by the cluster components.
+
+config phase1.azure.subscription_id
+	string "ActiveDirectory ServicePrincipal ClientSecret"
+	help
+		The ClientSecret of the Service Account to be used by the cluster components.
+
+config phase1.azure.client_id
+	string "ActiveDirectory ServicePrincipal ClientID"
+	help
+		The ClientID of the Service Account to be used by the cluster components.
+
+config phase1.azure.client_secret
+	string "ActiveDirectory ServicePrincipal ClientSecret"
+	help
+		The ClientSecret of the Service Account to be used by the cluster components.
+
+endmenu

--- a/phase1/azure/Kconfig
+++ b/phase1/azure/Kconfig
@@ -35,7 +35,7 @@ config phase1.azure.node_vm_size
 
 config phase1.azure.master_private_ip
 	string "Private IP address of Master"
-	default "10.0.1.4"
+	default "10.240.1.4"
 	help
 		The private ip address of master
 

--- a/phase1/azure/all.jsonnet
+++ b/phase1/azure/all.jsonnet
@@ -1,0 +1,4 @@
+local cfg = import "../../.config.json";
+{
+  ["azure-%(instance_prefix)s.tf" % cfg.phase1]: (import "azure.jsonnet")(cfg),
+}

--- a/phase1/azure/azure.json
+++ b/phase1/azure/azure.json
@@ -1,0 +1,11 @@
+{
+  "tenantId": "${tenantId}",
+  "subscriptionId": "${subscriptionId}",
+  "adClientId": "${adClientId}",
+  "adClientSecret": "${adClientSecret}",
+  "resourceGroup": "${resourceGroup}",
+  "location": "${location}",
+  "subnetName": "${subnetName}",
+  "securityGroupName": "${securityGroupName}",
+  "vnetName": "${vnetName}"
+}

--- a/phase1/azure/azure.jsonnet
+++ b/phase1/azure/azure.jsonnet
@@ -94,7 +94,7 @@ function(config)
           resource_group_name: "${azurerm_resource_group.rg.name}",
           name: names.subnet,
           virtual_network_name: "${azurerm_virtual_network.vnet.name}",
-          address_prefix: "10.0.0.0/16",
+          address_prefix: "10.240.0.0/16",
           network_security_group_id: "${azurerm_network_security_group.sg.id}",
           route_table_id: "${azurerm_route_table.rt.id}",
         },
@@ -292,7 +292,7 @@ function(config)
             master_private_ip,
             # master service ip, this depends on the cluster cidr
             # so must be changed if/when we allow that to be configured
-            "10.3.0.1",
+            "10.0.0.1",
           ]
         ),
       },

--- a/phase1/azure/azure.jsonnet
+++ b/phase1/azure/azure.jsonnet
@@ -1,0 +1,313 @@
+function(config)
+  local tf = import "phase1/tf.jsonnet";
+  local cfg = config.phase1;
+  local master_private_ip = cfg.azure.master_private_ip;
+  local names = {
+    resource_group: "%(instance_prefix)s" % cfg,
+    master_public_ip: "%(instance_prefix)s-master-pip" % cfg,
+    availability_set: "%(instance_prefix)s-as" % cfg,
+    storage_account: "${replace(\"%(instance_prefix)sstrg\", \"-\", \"\")}" % cfg,
+    storage_container: "strg%(instance_prefix)s" % cfg,
+    vnet: "%(instance_prefix)s-vnet" % cfg,
+    subnet: "%(instance_prefix)s-subnet" % cfg,
+    route_table: "%(instance_prefix)s" % cfg,
+    security_group: "%(instance_prefix)s-nsg" % cfg,
+    master_nic: "%(instance_prefix)s-master-nic" % cfg,
+    master_vm: "%(instance_prefix)s-master" % cfg,
+    node_nic: "%(instance_prefix)s-node-nic" % cfg,
+    node_vm: "%(instance_prefix)s-node" % cfg,
+  };
+  local kubeconfig(user) =
+    std.manifestJson(
+      tf.pki.kubeconfig_from_certs(
+        user,
+        "root",
+        "https://${azurerm_public_ip.pip.ip_address}",
+      ));
+  {
+    variable: {
+      subscription_id: { default: cfg.azure.subscription_id },
+      tenant_id: { default: cfg.azure.tenant_id },
+      client_id: { default: cfg.azure.client_id },
+      client_secret: { default: cfg.azure.client_secret },
+    },
+    output: {
+      [names.master_public_ip]: {
+        value: "${azurerm_public_ip.pip.ip_address}",
+      },
+    },
+    provider: {
+      azurerm: {
+        subscription_id: "${var.subscription_id}",
+        tenant_id: "${var.tenant_id}",
+        client_id: "${var.client_id}",
+        client_secret: "${var.client_secret}",
+      },
+    },
+    resource: {
+      azurerm_resource_group: {
+        rg: {
+          name: names.resource_group,
+          location: cfg.azure.location,
+        },
+      },
+      azurerm_storage_account: {
+        sa: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          name: names.storage_account,
+          location: "${azurerm_resource_group.rg.location}",
+          account_type: "Standard_LRS",
+        },
+      },
+      azurerm_storage_container: {
+        sc: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          storage_account_name: "${azurerm_storage_account.sa.name}",
+          name: names.storage_container,
+          container_access_type: "private",
+        },
+      },
+      azurerm_availability_set: {
+        as: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          name: names.availability_set,
+          location: "${azurerm_resource_group.rg.location}",
+        },
+      },
+      azurerm_virtual_network: {
+        vnet: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          location: "${azurerm_resource_group.rg.location}",
+          name: names.vnet,
+          address_space: ["10.0.0.0/8"],
+        },
+      },
+      azurerm_route_table: {
+        rt: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          location: "${azurerm_resource_group.rg.location}",
+          name: names.route_table,
+        },
+      },
+      azurerm_subnet: {
+        subnet: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          name: names.subnet,
+          virtual_network_name: "${azurerm_virtual_network.vnet.name}",
+          address_prefix: "10.0.0.0/16",
+          network_security_group_id: "${azurerm_network_security_group.sg.id}",
+          route_table_id: "${azurerm_route_table.rt.id}",
+        },
+      },
+      azurerm_network_security_group: {
+        sg: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          location: cfg.azure.location,
+          name: names.security_group,
+        },
+      },
+      azurerm_network_security_rule: {
+        [cfg.instance_prefix + "-master-ssh"]: {
+          name: "%(instance_prefix)s-master-ssh" % cfg,
+          priority: 100,
+          direction: "Inbound",
+          access: "Allow",
+          protocol: "Tcp",
+          source_port_range: "*",
+          destination_port_range: "22",
+          source_address_prefix: "*",
+          destination_address_prefix: "*",
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          network_security_group_name: "${azurerm_network_security_group.sg.name}",
+        },
+        [cfg.instance_prefix + "-master-ssl"]: {
+          name: "%(instance_prefix)s-master-ssl" % cfg,
+          priority: 110,
+          direction: "Inbound",
+          access: "Allow",
+          protocol: "Tcp",
+          source_port_range: "*",
+          destination_port_range: "443",
+          source_address_prefix: "*",
+          destination_address_prefix: "*",
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          network_security_group_name: "${azurerm_network_security_group.sg.name}",
+        },
+      },
+      azurerm_public_ip: {
+        pip: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          location: cfg.azure.location,
+          name: names.master_public_ip,
+          public_ip_address_allocation: "static",
+        },
+      },
+      azurerm_network_interface: {
+        master_nic: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          location: "${azurerm_resource_group.rg.location}",
+          name: names.master_nic,
+          ip_configuration: {
+            name: "ipconfig",
+            subnet_id: "${azurerm_subnet.subnet.id}",
+            private_ip_address_allocation: "static",
+            private_ip_address: master_private_ip,
+            public_ip_address_id: "${azurerm_public_ip.pip.id}",
+          },
+          enable_ip_forwarding: true,
+        },
+        node_nic: {
+          resource_group_name: "${azurerm_resource_group.rg.name}",
+          location: "${azurerm_resource_group.rg.location}",
+          name: names.node_nic + "-${count.index}",
+          ip_configuration: {
+            name: "ipconfig",
+            subnet_id: "${azurerm_subnet.subnet.id}",
+            private_ip_address_allocation: "Dynamic",
+          },
+          enable_ip_forwarding: true,
+          count: cfg.num_nodes,
+        },
+      },
+      template_file: {
+        azure_json: {
+          template: "${file(\"azure.json\")}",
+          vars: {
+            tenantId: "${var.tenant_id}",
+            subscriptionId: "${var.subscription_id}",
+            adClientId: "${var.client_id}",
+            adClientSecret: "${var.client_secret}",
+            resourceGroup: "${azurerm_resource_group.rg.name}",
+            location: "${azurerm_resource_group.rg.location}",
+            subnetName: "${azurerm_subnet.subnet.name}",
+            securityGroupName: "${azurerm_network_security_group.sg.name}",
+            vnetName: "${azurerm_virtual_network.vnet.name}",
+          },
+        },
+        configure_vm: {
+          template: "${file(\"configure-vm.sh\")}",
+          vars: {
+            root_ca_public_pem: "${base64encode(tls_self_signed_cert.root.cert_pem)}",
+            apiserver_cert_pem: "${base64encode(tls_locally_signed_cert.master.cert_pem)}",
+            apiserver_key_pem: "${base64encode(tls_private_key.master.private_key_pem)}",
+            node_kubeconfig: kubeconfig("node"),
+            k8s_config: "${base64encode(file(\"../../.config.json\"))}",
+            azure_json: "${base64encode(template_file.azure_json.rendered)}",
+          },
+        },
+      },
+      azurerm_virtual_machine: {
+        master_vm: {
+          resource_group_name: names.resource_group,
+          location: "${azurerm_resource_group.rg.location}",
+          name: names.master_vm,
+          network_interface_ids: ["${azurerm_network_interface.master_nic.id}"],
+          vm_size: cfg.azure.master_vm_size,
+          availability_set_id: "${azurerm_availability_set.as.id}",
+
+          storage_image_reference: {
+            publisher: cfg.azure.image_publisher,
+            offer: cfg.azure.image_offer,
+            sku: cfg.azure.image_sku,
+            version: cfg.azure.image_version,
+          },
+
+          storage_os_disk: {
+            name: names.master_vm + "-osdisk",
+            vhd_uri: "${azurerm_storage_account.sa.primary_blob_endpoint}${azurerm_storage_container.sc.name}/" + names.master_vm + "-osdisk.vhd",
+            caching: "ReadWrite",
+            create_option: "FromImage",
+          },
+
+          os_profile: {
+            computer_name: names.master_vm,
+            admin_username: cfg.azure.admin_username,
+            admin_password: cfg.azure.admin_password,
+            custom_data: "${base64encode(template_file.configure_vm.rendered)}",
+          },
+
+          os_profile_linux_config: {
+            disable_password_authentication: false,
+          },
+        },
+        node_vm: {
+          resource_group_name: names.resource_group,
+          location: "${azurerm_resource_group.rg.location}",
+          name: names.node_vm + "-${count.index}",
+          network_interface_ids: ["${element(azurerm_network_interface.node_nic.*.id, count.index)}"],
+          vm_size: cfg.azure.node_vm_size,
+          availability_set_id: "${azurerm_availability_set.as.id}",
+
+          storage_image_reference: {
+            publisher: cfg.azure.image_publisher,
+            offer: cfg.azure.image_offer,
+            sku: cfg.azure.image_sku,
+            version: cfg.azure.image_version,
+          },
+
+          storage_os_disk: {
+            name: names.node_vm + "-${count.index}-osdisk",
+            vhd_uri: "${azurerm_storage_account.sa.primary_blob_endpoint}${azurerm_storage_container.sc.name}/" + names.node_vm + "${count.index}-osdisk.vhd",
+            caching: "ReadWrite",
+            create_option: "FromImage",
+          },
+
+          os_profile: {
+            computer_name: names.node_vm + "-${count.index}",
+            admin_username: cfg.azure.admin_username,
+            admin_password: cfg.azure.admin_password,
+            custom_data: "${base64encode(template_file.configure_vm.rendered)}",
+          },
+
+          os_profile_linux_config: {
+            disable_password_authentication: false,
+          },
+
+          count: cfg.num_nodes,
+        },
+      },
+      tls_private_key: {
+        [name]: tf.pki.private_key
+        for name in ["root", "node", "master", "admin"]
+      },
+      tls_self_signed_cert: {
+        root: tf.pki.tls_self_signed_cert("root"),
+      },
+      tls_cert_request: {
+        [name]: tf.pki.tls_cert_request(name)
+        for name in ["node", "admin"]
+      } {
+        master: tf.pki.tls_cert_request(
+          "master",
+          dns_names=[
+            "kubernetes",
+            "kubernetes.default",
+            "kubernetes.default.svc",
+            "kubernetes.default.svc.local",
+            "kubernetes.default.svc.local",
+            names.master_vm,
+          ],
+          ip_addresses=[
+            "${azurerm_public_ip.pip.ip_address}",
+            master_private_ip,
+            # master service ip, this depends on the cluster cidr
+            # so must be changed if/when we allow that to be configured
+            "10.3.0.1",
+          ]
+        ),
+      },
+      tls_locally_signed_cert: {
+        [name]: tf.pki.tls_locally_signed_cert(name, "root")
+        for name in ["node", "master", "admin"]
+      },
+      null_resource: {
+        kubeconfig: {
+          provisioner: [{
+            "local-exec": {
+              command: "echo '%s' > ./.tmp/kubeconfig.json" % kubeconfig("admin"),
+            },
+          }],
+        },
+      },
+    },
+  }

--- a/phase1/azure/configure-vm.sh
+++ b/phase1/azure/configure-vm.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+set -x
+set -o errexit
+set -o pipefail
+set -o nounset
+
+mkdir -p /etc/systemd/system/docker.service.d/
+cat <<EOF > /etc/systemd/system/docker.service.d/clear_mount_propagtion_flags.conf
+[Service]
+MountFlags=shared
+EOF
+cat <<EOF > /etc/systemd/system/docker.service.d/overlay.conf
+[Service]
+ExecStart=
+ExecStart=/usr/bin/docker daemon -H fd:// --storage-driver=overlay
+EOF
+
+# start hacky workaround (https://github.com/docker/docker/issues/23793)
+  curl -sSL https://get.docker.com/ > /tmp/install-docker
+  chmod +x /tmp/install-docker
+  /tmp/install-docker || true
+  systemctl start docker || true
+# end hacky workaround
+
+apt-get install -y jq
+
+ROLE="node"
+if [[ $(hostname) = *master* ]]; then
+  ROLE="master"
+fi
+
+azure_file="/etc/kubernetes/azure.json"
+config_file="/etc/kubernetes/k8s_config.json"
+
+mkdir -p /etc/kubernetes
+mkdir -p /srv/kubernetes
+
+# the following values are populated by terraform
+echo -n "${azure_json}" | base64 -d > "$azure_file"
+echo -n "${k8s_config}" | base64 -d > "$config_file"
+echo -n "${root_ca_public_pem}" | base64 -d > "/srv/kubernetes/ca.pem"
+echo -n "${apiserver_cert_pem}" | base64 -d > "/srv/kubernetes/apiserver.pem"
+echo -n "${apiserver_key_pem}" | base64 -d > "/srv/kubernetes/apiserver-key.pem"
+cat << EOF > "/srv/kubernetes/kubeconfig.json"
+${node_kubeconfig}
+EOF
+
+MASTER_IP="$(cat "$config_file" | jq -r '.phase1.azure.master_private_ip')"
+
+jq ". + {\"role\": \"$ROLE\", \"master_ip\": \"$MASTER_IP\"}" "$config_file" > /etc/kubernetes/k8s_config.new; cp /etc/kubernetes/k8s_config.new "$config_file"
+
+installer_container="$(jq -r '.phase2.installer_container' "$config_file")"
+
+docker pull "$installer_container"
+docker run \
+  --net=host \
+  -v /:/host_root \
+  -v /etc/kubernetes/k8s_config.json:/opt/playbooks/config.json:ro \
+  "$installer_container" \
+  /opt/do_role.sh "$ROLE"

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -x
+
+cd "${BASH_SOURCE%/*}"
+
+gen() {
+  mkdir -p .tmp/
+  jsonnet -J ../../ --multi .tmp/ all.jsonnet
+}
+
+deploy() {
+  gen
+  
+  # Workaround: https://github.com/hashicorp/terraform/issues/7153
+  terraform apply .tmp || true
+  
+  # TODO: this dumps tfstate into ./azure/ rather than ./azure/.tmp/
+  terraform apply .tmp
+}
+
+destroy() {
+  terraform destroy .tmp
+}
+
+case "${1:-}" in
+  "")
+    ;;
+  "deploy")
+    deploy
+    ;;
+  "destroy")
+    destroy
+    ;;
+  "gen")
+    gen
+    ;;
+esac

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -16,10 +16,10 @@ deploy() {
   gen
   
   # Workaround: https://github.com/hashicorp/terraform/issues/7153
-  terraform apply .tmp || true
+  terraform apply -state=./.tmp/terraform.tfstate .tmp || true
   
   # TODO: this dumps tfstate into ./azure/ rather than ./azure/.tmp/
-  terraform apply .tmp
+  terraform apply -state=./.tmp/terraform.tfstate .tmp
 }
 
 destroy() {

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -1,6 +1,10 @@
 
 menu "Phase 2: Node Bootstrapping"
 
+config phase2.installer_container
+	string "installer container"
+	default "docker.io/colemickens/install-k8s:v1"
+
 config phase2.docker_registry
 	string "docker registry"
 	default "gcr.io/google-containers"

--- a/phase2/ansible/Makefile
+++ b/phase2/ansible/Makefile
@@ -1,5 +1,5 @@
-TAG=v2
-IMAGE=gcr.io/mikedanese-k8s/install-k8s
+TAG?=v2
+IMAGE?=gcr.io/mikedanese-k8s/install-k8s
 
 build:
 	docker build -t "$(IMAGE):$(TAG)" .

--- a/phase2/ansible/playbooks/roles/master/templates/etcd.jsonnet
+++ b/phase2/ansible/playbooks/roles/master/templates/etcd.jsonnet
@@ -1,4 +1,10 @@
 function(cfg)
+  local etcdPath =
+    if cfg.phase1.cloud_provider == "gce" then
+      "/mnt/master-pd/var/etcd"
+    else
+      "/var/etcd";
+
   {
     apiVersion: "v1",
     kind: "Pod",
@@ -62,7 +68,7 @@ function(cfg)
         {
           name: "varetcd",
           hostPath: {
-            path: "/mnt/master-pd/var/etcd",
+            path: etcdPath,
           },
         },
       ],

--- a/phase2/ansible/playbooks/roles/master/templates/kube-controller-manager.jsonnet
+++ b/phase2/ansible/playbooks/roles/master/templates/kube-controller-manager.jsonnet
@@ -29,7 +29,7 @@ function(cfg)
               "/hyperkube",
               "controller-manager",
               "--master=127.0.0.1:8080",
-              "--cluster-name=k-1",
+              "--cluster-name=" + cfg.phase1.instance_prefix,
               "--cluster-cidr=10.244.0.0/16",
               "--allocate-node-cidrs=true",
               "--cloud-provider=%s" % cfg.phase1.cloud_provider,

--- a/phase2/ansible/playbooks/roles/master/templates/kube-controller-manager.jsonnet
+++ b/phase2/ansible/playbooks/roles/master/templates/kube-controller-manager.jsonnet
@@ -1,3 +1,6 @@
+local build_params(arr) =
+  std.flattenArrays(std.filter(function(a) a != null, arr));
+
 function(cfg)
   {
     apiVersion: "v1",
@@ -15,27 +18,28 @@ function(cfg)
       containers: [
         {
           name: "kube-controller-manager",
-          image: "%(docker_registry)s/kube-controller-manager:%(kubernetes_version)s" % cfg.phase2,
+          image: "%(docker_registry)s/hyperkube-amd64:%(kubernetes_version)s" % cfg.phase2,
           resources: {
             requests: {
               cpu: "200m",
             },
           },
-          command: [
-            "/bin/sh",
-            "-c",
-            |||
-              /usr/local/bin/kube-controller-manager \
-                --master=127.0.0.1:8080 \
-                --cluster-name=k-1 \
-                --cluster-cidr=10.244.0.0/16 \
-                --allocate-node-cidrs=true \
-                --cloud-provider=%(cloud_provider)s \
-                --service-account-private-key-file=/srv/kubernetes/apiserver-key.pem \
-                --root-ca-file=/srv/kubernetes/ca.pem \
-                --v=2
-            ||| % cfg.phase1,
-          ],
+          command: build_params([
+            [
+              "/hyperkube",
+              "controller-manager",
+              "--master=127.0.0.1:8080",
+              "--cluster-name=k-1",
+              "--cluster-cidr=10.244.0.0/16",
+              "--allocate-node-cidrs=true",
+              "--cloud-provider=%s" % cfg.phase1.cloud_provider,
+              "--service-account-private-key-file=/srv/kubernetes/apiserver-key.pem",
+              "--root-ca-file=/srv/kubernetes/ca.pem",
+              "--v=2",
+            ],
+            if cfg.phase1.cloud_provider == "azure" then
+              ["--cloud-config=/etc/kubernetes/azure.json"],
+          ]),
           livenessProbe: {
             httpGet: {
               host: "127.0.0.1",
@@ -52,6 +56,11 @@ function(cfg)
               readOnly: true,
             },
             {
+              name: "etckube",
+              mountPath: "/etc/kubernetes",
+              readOnly: true,
+            },
+            {
               name: "etcssl",
               mountPath: "/etc/ssl",
               readOnly: true,
@@ -64,6 +73,12 @@ function(cfg)
           name: "srvkube",
           hostPath: {
             path: "/srv/kubernetes",
+          },
+        },
+        {
+          name: "etckube",
+          hostPath: {
+            path: "/etc/kubernetes",
           },
         },
         {

--- a/phase2/ansible/playbooks/roles/master/templates/kube-scheduler.jsonnet
+++ b/phase2/ansible/playbooks/roles/master/templates/kube-scheduler.jsonnet
@@ -15,16 +15,17 @@ function(cfg)
       containers: [
         {
           name: "kube-scheduler",
-          image: "%(docker_registry)s/kube-scheduler:%(kubernetes_version)s" % cfg.phase2,
+          image: "%(docker_registry)s/hyperkube-amd64:%(kubernetes_version)s" % cfg.phase2,
           resources: {
             requests: {
               cpu: "100m",
             },
           },
           command: [
-            "/bin/sh",
-            "-c",
-            "/usr/local/bin/kube-scheduler --master=127.0.0.1:8080 --v=2",
+            "/hyperkube",
+            "scheduler",
+            "--master=127.0.0.1:8080",
+            "--v=2",
           ],
           livenessProbe: {
             httpGet: {

--- a/phase2/ansible/playbooks/roles/node/tasks/main.yml
+++ b/phase2/ansible/playbooks/roles/node/tasks/main.yml
@@ -19,3 +19,4 @@
 - service:
     name: kubelet
     state: started
+    enabled: yes

--- a/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
+++ b/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
@@ -13,27 +13,29 @@ ExecStart=/usr/bin/docker run \
         -v /sys:/sys:ro \
         -v /var/run:/var/run:rw \
         -v /var/lib/docker/:/var/lib/docker:rw \
-        -v /var/lib/kubelet/:/var/lib/kubelet:rw,shared \
+        -v /var/lib/kubelet/:/var/lib/kubelet:shared \
         -v /srv/kubernetes:/srv/kubernetes:ro \
-        -v /etc/kubernetes/manifests:/etc/kubernetes/manifests:ro \
+        -v /etc/kubernetes:/etc/kubernetes:ro \
         {{ phase2['docker_registry'] }}/hyperkube-amd64:{{ phase2['kubernetes_version'] }} \
         /hyperkube kubelet \
             --address=0.0.0.0 \
             --allow-privileged=true \
             --cloud-provider={{ phase1['cloud_provider'] }} \
+{% if phase1['cloud_provider'] == "azure" %}
+            --cloud-config="/etc/kubernetes/azure.json" \
+{% endif %}
             --enable-server \
-{% if role == "master" %}
-            --api-servers=http://localhost:8080 \
-{% elif role == "node" %}
+            --register-schedulable={{ role == "node" }} \
             --enable-debugging-handlers \
             --api-servers=https://{{ master_ip }} \
-            --hairpin-mode=promiscuous-bridge \
             --kubeconfig=/srv/kubernetes/kubeconfig.json \
+            --config=/etc/kubernetes/manifests \
+{% if role == "node" %}
+            --hairpin-mode=promiscuous-bridge \
             --network-plugin=kubenet \
             --reconcile-cidr \
 {% endif %}
-            --config=/etc/kubernetes/manifests \
-            --cluster-dns=10.0.0.10 \
+            --cluster-dns=10.3.0.10 \
             --cluster-domain=cluster.local \
             --v=2
 Restart=always

--- a/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
+++ b/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
@@ -35,7 +35,7 @@ ExecStart=/usr/bin/docker run \
             --network-plugin=kubenet \
             --reconcile-cidr \
 {% endif %}
-            --cluster-dns=10.3.0.10 \
+            --cluster-dns=10.0.0.10 \
             --cluster-domain=cluster.local \
             --v=2
 Restart=always

--- a/util/config_to_json
+++ b/util/config_to_json
@@ -22,7 +22,7 @@ while read line; do
   field=$(echo "${line}" \
     | cut -f1 -d"=")
   value=$(echo "${line}" \
-    | cut -f2 -d"=" \
+    | cut -f2- -d"=" \
     | sed \
       -e 's/^y$/true/' \
       -e 's/^n$/false/')


### PR DESCRIPTION
Of the remaining issues in [the closed min-turnup PR](https://github.com/kubernetes/kube-deploy/pull/106):

1. "terraform resource names": I still punted on this. I've started to a couple times, but it's a rather surprisingly large amount of extra changes/text with unclear benefit to me. In terms of enabling side-by-side deployments, it seems there are other problems to sort out. (Comparing to the GCE one, it looks like GCE is going to hit the same "multiple resources with same name" error due to the TLS/kubeconfig assets not being named uniquely per-`instance_prefix`.) I still think it'd be better to support multiple clusters by having entirely separate directories per-cluster. With their own separate `tfstate`s, `kubeconfig`s, etc.

2. "prefer jsonnet": I've added the Azure cloud config file parameter into the kube-{apiserver,scheduler} jsonnet templates rather than rewriting them to jinja2. (**Jinja2 is still used by `kubelet.service`.** I just added my parameters and left the templating language as I found it)

3. "pki in terraform": Mike did this in https://github.com/kubernetes/kubernetes-anywhere/pull/146

Please Note:

1. Workaround 1: Docker start fails after install. https://github.com/colemickens/kubernetes-anywhere/blob/5007ff0daa04ea32d81ea463ed72c50f73539c83/phase1/azure/configure-vm.sh#L19

2. Workaround 2: Terraform bug that causes flakiness in Azure: https://github.com/colemickens/kubernetes-anywhere/blob/5007ff0daa04ea32d81ea463ed72c50f73539c83/phase1/azure/do#L18

3. I'm not sure which is correct for kubelet's volume share mode. In this branch, it's already at `-v /var/lib/kubelet/:/var/lib/kubelet:shared` but I had it `-v /var/lib/kubelet/:/var/lib/kubelet:rw,shared` in `min-turnup` originally. Which is correct, and why?


CC: @mikedanese @errordeveloper 