### PR TITLE
WIP/Discussion: support multiple clusters based on cloud_provider/instance_prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .config.old
 .config.json
 **/kubeconfig.json
+clusters/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ RUN apt-get update && apt-get -y upgrade && \
 RUN npm install -g azure-cli
 
 # Install Jsonnet
-# ENV JSONNET_GIT_TAG v0.8.8
-#     (too old - std.manifestJson is missing)
-ENV JSONNET_GIT_TAG master
+ENV JSONNET_GIT_TAG v0.8.9
 RUN cd /tmp \
     && git clone https://github.com/google/jsonnet \
     && cd jsonnet \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y upgrade \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Terraform
-ENV TERRAFORM_VERSION 0.7.0-rc1
+ENV TERRAFORM_VERSION 0.7.0-rc3
 RUN curl -sSL --fail \
     "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
     -o /tmp/tf.zip \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ menuconfig: .tmp/mconf
 # i'm awful at make, clean this up
 prep:
 	$(eval CLOUD_PROVIDER := $(shell jq -r '.phase1.cloud_provider' .config.json))
-	$(eval INSTANCE_PREFIX=$(shell jq -r '.phase1.instance_prefix' .config.json))
+	$(eval INSTANCE_PREFIX=$(shell jq -r '.phase1.cluster_name' .config.json))
 	$(eval DEST=clusters/$(CLOUD_PROVIDER)/$(INSTANCE_PREFIX))
 	mkdir -p "$(DEST)"
 	cp -a "phase1/$(CLOUD_PROVIDER)/." "$(DEST)/"
@@ -56,7 +56,7 @@ deploy destroy: prep
 
 do:
 	$(eval CLOUD_PROVIDER := $(shell jq -r '.phase1.cloud_provider' .config.json))
-	$(eval INSTANCE_PREFIX=$(shell jq -r '.phase1.instance_prefix' .config.json))
+	$(eval INSTANCE_PREFIX=$(shell jq -r '.phase1.cluster_name' .config.json))
 	$(eval DEST=clusters/$(CLOUD_PROVIDER)/$(INSTANCE_PREFIX))
 	( cd "$(DEST)"; ./do $(WHAT) )
 

--- a/Makefile
+++ b/Makefile
@@ -39,24 +39,32 @@ menuconfig: .tmp/mconf
 .config.json: .config
 	util/config_to_json $< > $@
 
+# i'm awful at make, clean this up
+prep:
+	$(eval CLOUD_PROVIDER := $(shell jq -r '.phase1.cloud_provider' .config.json))
+	$(eval INSTANCE_PREFIX=$(shell jq -r '.phase1.instance_prefix' .config.json))
+	$(eval DEST=clusters/$(CLOUD_PROVIDER)/$(INSTANCE_PREFIX))
+	mkdir -p "$(DEST)"
+	cp -a "phase1/$(CLOUD_PROVIDER)/." "$(DEST)/"
+	cp ".config.json" "$(DEST)/config.json"
+
 echo-config: .config.json
 	cat $<
 
-deploy destroy: .config.json
+deploy destroy: prep
 	$(MAKE) do WHAT=$@
 
 do:
-	( cd "phase1/$$(jq -r '.phase1.cloud_provider' .config.json)"; ./do $(WHAT) )
+	$(eval CLOUD_PROVIDER := $(shell jq -r '.phase1.cloud_provider' .config.json))
+	$(eval INSTANCE_PREFIX=$(shell jq -r '.phase1.instance_prefix' .config.json))
+	$(eval DEST=clusters/$(CLOUD_PROVIDER)/$(INSTANCE_PREFIX))
+	( cd "$(DEST)"; ./do $(WHAT) )
 
 docker-build:
 	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
 
-docker-run: docker-build
-	docker run -it --net=host $(IMAGE_NAME):$(IMAGE_VERSION) /bin/bash
-
-docker-dev: docker-build
+env: docker-build
 	docker run -it --net=host -v `pwd`:/root/kubernetes-anywhere $(IMAGE_NAME):$(IMAGE_VERSION) /bin/bash
-
 
 clean:
 	rm -rf .tmp

--- a/phase1/azure/all.jsonnet
+++ b/phase1/azure/all.jsonnet
@@ -1,4 +1,4 @@
-local cfg = import "../../.config.json";
+local cfg = import "./config.json";
 {
   ["azure-%(cluster_name)s.tf" % cfg.phase1]: (import "azure.jsonnet")(cfg),
 }

--- a/phase1/azure/azure.jsonnet
+++ b/phase1/azure/azure.jsonnet
@@ -192,7 +192,7 @@ function(config)
             apiserver_cert_pem: "${base64encode(tls_locally_signed_cert.master.cert_pem)}",
             apiserver_key_pem: "${base64encode(tls_private_key.master.private_key_pem)}",
             node_kubeconfig: kubeconfig("node"),
-            k8s_config: "${base64encode(file(\"../../.config.json\"))}",
+            k8s_config: "${base64encode(file(\"./config.json\"))}",
             azure_json: "${base64encode(template_file.azure_json.rendered)}",
           },
         },
@@ -305,7 +305,7 @@ function(config)
         kubeconfig: {
           provisioner: [{
             "local-exec": {
-              command: "echo '%s' > ./.tmp/kubeconfig.json" % kubeconfig("admin"),
+              command: "echo '%s' > ./kubeconfig.json" % kubeconfig("admin"),
             },
           }],
         },

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -8,22 +8,21 @@ set -x
 cd "${BASH_SOURCE%/*}"
 
 gen() {
-  mkdir -p .tmp/
-  jsonnet -J ../../ --multi .tmp/ all.jsonnet
+  jsonnet -J ../../../ --multi ./ all.jsonnet
 }
 
 deploy() {
   gen
-  
+
   # Workaround: https://github.com/hashicorp/terraform/issues/7153
-  terraform apply -state=./.tmp/terraform.tfstate .tmp || true
-  
+  terraform apply || true
+
   # TODO: this dumps tfstate into ./azure/ rather than ./azure/.tmp/
-  terraform apply -state=./.tmp/terraform.tfstate .tmp
+  terraform apply
 }
 
 destroy() {
-  terraform destroy .tmp
+  terraform destroy
 }
 
 case "${1:-}" in


### PR DESCRIPTION
Something I tried out in the Azure phase1.

It treats `phase1/{{cloud_provider}}` as a template and copies it to `clusters/{{cloud_provider}}/{{instance_prefix}}`.

With this change I can change `.config.json` to modify just the `instance_prefix` and get multiple basically identical clusters. And I can go into one and modify `config.json` and re-run `./do deploy` and get my cluster updated (in particular scaled up).

Problems:

- [ ] not sure if this is what others were thinking
- [ ] makes a bit of a mess of the Makefile rule dependencies. I was struggling to get it to use the `.config.json` that was in place and not re-run the whole config process including re-running the Kconfig steps so I clobbered a bit to make it work
- [ ] It's not a fully isolated template, it still reaches up into `../../../phase1` for the `tf.jsonnet` file.

```shell
$ pwd

/root/kubernetes-anywhere

$ ls -R clusters/

clusters:
azure

clusters/azure:
colemick-ex

clusters/azure/colemick-ex:
all.jsonnet
azure-colemick-ex.tf
azure.json
azure.jsonnet
config.json
configure-vm.sh
do
Kconfig
kubeconfig.json
terraform.tfstate
terraform.tfstate.backup
```