### PR TITLE
Few improvements to Kconfig bits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - docker images
 
 script:
+  - shellcheck -x -s bash ./util/config_to_json
   - shellcheck -x -s bash ./phase1/google-compute-engine/{create,delete}-cluster.sh
   - make -C phase2/docker-images lint
   - make -C phase2/docker-images build

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,9 @@ KCONFIG_FILES = $(shell find . -name 'Kconfig')
 default:
 	$(MAKE) config
 
-.tmp/conf:
-	mkdir -p .tmp; curl -sSL --fail -o "$@" \
-		"https://storage.googleapis.com/public-mikedanese-k8s/kconfig/$(CONF_TOOL_VERSION)/$(OS)/conf"; \
-	chmod +x "$@"
-
-.tmp/mconf:
-	mkdir -p .tmp; curl -sSL --fail -o "$@" \
-		"https://storage.googleapis.com/public-mikedanese-k8s/kconfig/$(CONF_TOOL_VERSION)/$(OS)/mconf"; \
+.tmp/conf .tmp/mconf:
+	mkdir -p $(dir $@)
+	curl -sSL --fail -o "$@" "https://storage.googleapis.com/public-mikedanese-k8s/kconfig/$(CONF_TOOL_VERSION)/$(OS)/$(shell basename $@)"
 	chmod +x "$@"
 
 config: .tmp/conf

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,10 @@ default:
 	chmod +x "$@"
 
 config: .tmp/conf
-	CONFIG_="" .tmp/conf Kconfig
+	CONFIG_="." .tmp/conf Kconfig
 
 menuconfig: .tmp/mconf
-	CONFIG_="" .tmp/mconf Kconfig
+	CONFIG_="." .tmp/mconf Kconfig
 
 .config: .tmp/conf $(KCONFIG_FILES)
 	$(MAKE) config

--- a/util/config_to_json
+++ b/util/config_to_json
@@ -16,20 +16,14 @@ if [[ "$#" != 1 ]]; then
 fi
 
 KCONFIG="$1"
-OUT="{}"
 
-while read line; do
-  field=$(echo "${line}" \
-    | cut -f1 -d"=")
-  value=$(echo "${line}" \
-    | cut -f2- -d"=" \
-    | sed \
-      -e 's/^y$/true/' \
-      -e 's/^n$/false/')
-  OUT=$(
-    echo "${OUT}" |
-      jq ".${field}=${value}")
-done < <(cat "${KCONFIG}" \
-  | sed -r -e '/^(\s*#.*)?$/d')
+read_input_and_strip_comments() {
+  sed -r -e '/^(\s*#.*)?$/d' "${KCONFIG}"
+}
 
-echo "${OUT}"
+convert_boolean_types() {
+  sed -e 's/\(=\)[yY]$/\1true/' -e 's/\(=\)[nN]$/\1false/'
+}
+
+## `jq -n ".foo=true|.bar=false"` will generate `{ "foo": true, "bar": false }`
+jq -n "$(read_input_and_strip_comments | convert_boolean_types | paste -sd "|" -)"


### PR DESCRIPTION
For some reason current version has thrown this when I tried running
make in a container:
```
docker build .
...
> docker run 8d0b7ef3b34c
make config
make[1]: Entering directory '/root/kubernetes-anywhere'
mkdir -p .tmp; curl -sSL --fail -o ".tmp/conf" \
        "https://storage.googleapis.com/public-mikedanese-k8s/kconfig/4.6/linux/conf"; \
chmod +x ".tmp/conf"
curl: no URL specified!
curl: try 'curl --help' or 'curl --manual' for more information
/bin/sh: 2:     "https://storage.googleapis.com/public-mikedanese-k8s/kconfig/4.6/linux/conf"; \: not found
/bin/sh: 3: chmod +x ".tmp/conf": not found
Makefile:26: recipe for target '.tmp/conf' failed
make[1]: *** [.tmp/conf] Error 127
make[1]: Leaving directory '/root/kubernetes-anywhere'
make: *** [default] Error 2
Makefile:23: recipe for target 'default' failed
```

So I looked at it and realised the backslashes weren't needed, so I also ended-up reducing some duplication.

I also look at the JSON generator, and found it a bit hard to read, and while understanding what it does, I found how it can be improved.