### PR TITLE
fix kubelet mounts for logging

### DIFF
--- a/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
+++ b/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/docker run \
         -v /var/run:/var/run:rw \
         -v /var/lib/docker/:/var/lib/docker:rw \
         -v /var/lib/kubelet/:/var/lib/kubelet:shared \
+        -v /var/log/containers:/var/log/containers:rw \
         -v /srv/kubernetes:/srv/kubernetes:ro \
         -v /etc/kubernetes:/etc/kubernetes:ro \
         {{ phase2['docker_registry'] }}/hyperkube-amd64:{{ phase2['kubernetes_version'] }} \


### PR DESCRIPTION
Partially addresses #162.

This allows EFK to work. Without this no container logs are picked up.