### PR TITLE
Remove --allow-unauthenticated from apt-get call.

### DIFF
--- a/phase1/aws-ec2-terraform/secure-v1.2-user-data.yaml
+++ b/phase1/aws-ec2-terraform/secure-v1.2-user-data.yaml
@@ -197,7 +197,8 @@ write_files:
 
       systemctl daemon-reload
 
-      docker -v || env DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unauthenticated --force-yes  docker-engine
+      apt-key adv --recv-keys --keyserver keys.ubuntu.com F76221572C52609D
+      docker -v || env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes  docker-engine
 
       systemctl enable docker.service
       systemctl start docker.service


### PR DESCRIPTION
Adds the public key matching the docker-engine package, and authenticates the package during installation.

Addresses #173