### PR TITLE
Mount the /dev directory in the kubelet container so that it can detect persistent disks.

### DIFF
--- a/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
+++ b/phase2/ansible/playbooks/roles/node/templates/kubelet.service.j2
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/docker run \
         --net=host \
         --pid=host \
         --privileged \
+        -v /dev:/dev \
         -v /sys:/sys:ro \
         -v /var/run:/var/run:rw \
         -v /var/lib/docker/:/var/lib/docker:rw \


### PR DESCRIPTION
This seems to work.