### PR TITLE
fix failing dns e2e tests

### DIFF
--- a/phase3/kube-dns/kube-dns-rc.json
+++ b/phase3/kube-dns/kube-dns-rc.json
@@ -28,7 +28,6 @@
         "containers": [
           {
             "args": [
-              "--domain=local.",
               "--dns-port=10053"
             ],
             "image": "gcr.io/google_containers/kubedns-amd64:1.3",

--- a/phase3/kube-dns/kube-dns-svc.json
+++ b/phase3/kube-dns/kube-dns-svc.json
@@ -11,6 +11,7 @@
     "namespace": "kube-system"
   },
   "spec": {
+    "clusterIP": "10.0.0.10",
     "ports": [
       {
         "name": "dns",


### PR DESCRIPTION
I believe this fixes the failing DNS e2e tests. Note that this value matches the --cluster-dns kubelet parameter https://github.com/kubernetes/kubernetes-anywhere/blob/master/phase2/ignition/vanilla/node.jsonnet#L23

Testing now.