### PR TITLE
Mount the /dev directory in the kubelet container so that it can detect persistent disks.

### DIFF
--- a/phase2/ignition/vanilla/kubelet.service
+++ b/phase2/ignition/vanilla/kubelet.service
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/docker run \
         --net=host \
         --pid=host \
         --privileged \
+        -v /dev:/dev \
         -v /sys:/sys:ro \
         -v /var/run:/var/run:rw \
         -v /var/lib/docker/:/var/lib/docker:rw \


### PR DESCRIPTION
Looks like this commit (4bb4510592a701c3319c2fb0b22a7ceeacb3ab5f) from @madhusudancs got dropped when we moved from ansible->ignition.

This adds it back.