### PR TITLE
azure: test: add timeout waiting for cluster

### DIFF
--- a/test/azure/Jenkinsfile
+++ b/test/azure/Jenkinsfile
@@ -102,10 +102,10 @@ node {
 				sh("cp ./phase1/azure/.tmp/kubeconfig.json ./kubeconfig.json")
 				archiveArtifacts artifacts: 'kubeconfig.json', fingerprint: true
 
-
 				stage "Wait for Cluster"
-				sh("make validate")
-
+				timeout(time: 5, unit: 'MINUTES') {
+					sh("make validate")
+				}
 
 				stage 'Deploy Addons'
 				sh("make addons")


### PR DESCRIPTION
Deployments keep getting stuck. Either something is up with Azure networking or the Google storage bucket where `kubectl` is pulled from. If ignition fails to download `kubectl` it seems to fail out, and `kubelet.service` never gets created.

The pipeline then gets stuck waiting. For now, I'm adding the timeout in the Jenkins pipeline.