### PR TITLE
`make deploy` now waits for cluster and deploys addons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ menuconfig: .tmp/mconf
 echo-config: .config.json
 	cat $<
 
-deploy destroy: .config.json
+deploy-cluster destroy-cluster: .config.json
 	$(MAKE) do WHAT=$@
 
 validate:
@@ -50,6 +50,9 @@ validate:
 
 addons:
 	KUBECONFIG="$$(pwd)/phase1/$$(jq -r '.phase1.cloud_provider' .config.json)/.tmp/kubeconfig.json" ./phase3/do deploy
+
+deploy: | deploy-cluster validate addons
+destroy: | destroy-cluster
 
 do:
 	( cd "phase1/$$(jq -r '.phase1.cloud_provider' .config.json)"; ./do $(WHAT) )

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -21,7 +21,6 @@ deploy() {
   # Workaround: https://github.com/hashicorp/terraform/issues/7153
   terraform apply -state=./.tmp/terraform.tfstate .tmp || true
 
-  # TODO: this dumps tfstate into ./azure/ rather than ./azure/.tmp/
   terraform apply -state=./.tmp/terraform.tfstate .tmp
 }
 
@@ -36,10 +35,10 @@ destroy() {
 case "${1:-}" in
   "")
     ;;
-  "deploy")
+  "deploy-cluster")
     deploy
     ;;
-  "destroy")
+  "destroy-cluster")
     destroy
     ;;
   "gen")

--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -24,10 +24,10 @@ destroy() {
 case "${1:-}" in
   "")
     ;;
-  "deploy")
+  "deploy-cluster")
     deploy
     ;;
-  "destroy")
+  "destroy-cluster")
     destroy
     ;;
   "gen")

--- a/test/azure/Jenkinsfile
+++ b/test/azure/Jenkinsfile
@@ -102,15 +102,6 @@ node {
 				sh("cp ./phase1/azure/.tmp/kubeconfig.json ./kubeconfig.json")
 				archiveArtifacts artifacts: 'kubeconfig.json', fingerprint: true
 
-				stage "Wait for Cluster"
-				timeout(time: 5, unit: 'MINUTES') {
-					sh("make validate")
-				}
-
-				stage 'Deploy Addons'
-				sh("make addons")
-
-
 				if (testCluster=="y") {
 					stage 'Test Cluster'
 					withEnv(['KUBECONFIG=' + cwd() + '/phase1/azure/.tmp/kubeconfig.json']) {

--- a/util/validate
+++ b/util/validate
@@ -3,16 +3,18 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -x
 
-echo $KUBECONFIG
+wait_duration=10
 
-num_nodes="(( $(cat ./.config.json | jq -r '.phase1.num_nodes') + 1 ))"
+num_nodes="$(( $(cat ./.config.json | jq -r '.phase1.num_nodes') + 1 ))"
 
 while true; do
-  hcount=$(kubectl get nodes | grep 'Ready' | wc -l) || true
+  hcount=$(kubectl get nodes 2>/dev/null | grep 'Ready' | wc -l) || true
   [[ "${hcount}" -ge "${num_nodes}" ]] && exit
 
-  echo "healthy nodes: wanted: ${num_nodes} actual:${hcount}"
-  sleep 5
+  echo "Cluster is not yet healthy. Number of nodes: wanted:${num_nodes} actual:${hcount}"
+  echo "Waiting ${wait_duration}"
+  sleep ${wait_duration}
 done
+
+echo "Cluster is healthy!"


### PR DESCRIPTION
Note:

* I updated the string that `phase1/<provider>/do` expects to look for `{deploy,destroy}-cluster` to align with the target in the top-level `Makefile`. The functions inside `./do` that they map to are still just `deploy`/`destroy`.