### PR TITLE
Azure: Automatically provision Service Principal for user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ CONF_TOOL_VERSION = 4.6
 KCONFIG_FILES = $(shell find . -name 'Kconfig')
 
 default:
-	$(MAKE) deploy-all
+	$(MAKE) deploy
 
 config:
 	CONFIG_="." kconfig-conf Kconfig

--- a/phase1/azure/Kconfig
+++ b/phase1/azure/Kconfig
@@ -1,5 +1,25 @@
 menu "Azure configuration"
 
+config phase1.azure.subscription_id
+	string "Azure SubscriptionID"
+	help
+		The Azure Subscription ID
+
+config phase1.azure.tenant_id
+	string "Azure TenantID"
+	help
+		The Azure Tenant ID
+
+config phase1.azure.client_id
+	string "Azure Active Directory ServicePrincipal ClientID"
+	help
+		The ClientID of the Service Account to be used by the cluster components.
+
+config phase1.azure.client_secret
+	string "Azure Active Directory ServicePrincipal ClientSecret"
+	help
+		The ClientSecret of the Service Account to be used by the cluster components.
+
 config phase1.azure.image_publisher
 	string "Base Virtual Machine OS Image"
 	default "canonical"
@@ -52,25 +72,5 @@ config phase1.azure.admin_username
 config phase1.azure.admin_password
 	string "Virtual Machine Admin Password"
 	default "Ch@ng3ThisPassword"
-
-config phase1.azure.tenant_id
-	string "ActiveDirectory ServicePrincipal ClientSecret"
-	help
-		The ClientSecret of the Service Account to be used by the cluster components.
-
-config phase1.azure.subscription_id
-	string "ActiveDirectory ServicePrincipal ClientSecret"
-	help
-		The ClientSecret of the Service Account to be used by the cluster components.
-
-config phase1.azure.client_id
-	string "ActiveDirectory ServicePrincipal ClientID"
-	help
-		The ClientID of the Service Account to be used by the cluster components.
-
-config phase1.azure.client_secret
-	string "ActiveDirectory ServicePrincipal ClientSecret"
-	help
-		The ClientSecret of the Service Account to be used by the cluster components.
 
 endmenu

--- a/phase1/azure/README.md
+++ b/phase1/azure/README.md
@@ -45,6 +45,14 @@ make deploy
   * phase1.azure.subscription_id = "[azure_subscription_id]"
   ```
 
+  You may skip these fields, and the deployment will offer to fill them in for you:
+
+  ```
+  * phase1.azure.tenant_id
+  * phase1.azure.client_id
+  * phase1.azure.client_secret
+  ```
+
 ## Congratulations!
 
 You have a Kubernetes cluster!

--- a/phase1/azure/README.md
+++ b/phase1/azure/README.md
@@ -8,25 +8,12 @@ This will deploy a Kubernetes cluster into Azure.
 
 Required software:
   * `docker` for executing the `kubernetes-anywhere` deployment
+  * `make` for entering the deployment environment
   * `kubectl` for working with the cluster after deployment
 
 Required information:
   * Azure Subscription ID (The ID of the Subscription that this cluster will be deployed to)
-  * Azure Tenant ID (The ID of the AAD Tenant to which the Azure Service Principal belongs)
-  * Azure Service Principal Client ID (The Client ID (or Application Identifier URL) of your Service Principal)
-  * Azure Service Principal Client Secret (The Client Secret (or Password) of your Service Principal)
 
-#### Create a new Azure Service Principal (optional)
-
-If you don't already have an Azure Service Principal created for this deployment and cluster,
-you can perform the following to create one. You'll want to make sure your Azure CLI is configured for the
-same subscription as you're planning to deploy into.
-
-```shell
-wget https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/phase1/azure/create-azure-service-principal.sh -O ./create-azure-service-principal.sh
-chmod +x ./create-azure-service-principal.sh
-./create-azure-service-principal.sh
-```
 
 ## Deployment
 
@@ -50,26 +37,13 @@ make deploy
 ```
 
 **Notes**:
-* For now, the name chosen for `phase1.cluster_name` needs to be globally unique.
+* The name chosen for `phase1.cluster_name` needs to be globally unique.
 
 * To properly boot a cluster in Azure, you MUST set these values in the wizard:
 
   ```
-  * phase1.azure.tenant_id = "[azure_tenant_id]"
   * phase1.azure.subscription_id = "[azure_subscription_id]"
-  * phase1.azure.client_id = "[azure_client_id]"
-  * phase1.azure.client_secret = "[azure_client_secret]"
   ```
-
-  ```
-  * phase2.docker_registry = "gcr.io/google_containers"
-  * phase2.kubernetes_version = "v1.4.0-alpha.2"
-  * phase2.installer_container = "docker.io/colemickens/k8s-ignition:latest
-  ```
-
-* It is **highly** recommended that you leave the `phase3` options on the default settings.
-  By default, all of the addons will be deployed.
-  Most Kubernetes usages and examples will expect them.
 
 ## Congratulations!
 
@@ -80,7 +54,7 @@ Let's copy your `kubeconfig.json` file somewhere for safe-keeping.
 You'll need to do this outside of the `kubernetes-anywhere` deployment environment so that it is usable later.
 
 ```shell
-mkdir ~/.kube/config
+mkdir -p ~/.kube/config
 cp ./phase1/azure/.tmp/kubeconfig.json ~/.kube/config
 ```
 
@@ -118,7 +92,27 @@ Enjoy your Kubernetes cluster on Azure!
 
 ## Notes
 
-* Currently, this service principal is used both for driving the deployment in Terraform as well as powering the cloudprovider in the cluster. This means that you
+### Between Deployments
+At times, it can be helpful to run `make clean`. Note that this will remove the Terraform state files, requiring you to manually remove the cluster. Fortunately this is easy in Azure, and just requires you to remove the resource group created by the deployment.
+
+### Service Principal Permission Scope
+Currently, this service principal is used both for driving the deployment in Terraform as well as powering the cloudprovider in the cluster. This means that you
 either need to grant the Service Principal `Contributor` level access to the entire subscription, or you need to make the Resource Group ahead of time and grant
 the Service Principal access to just that specific Resource Group.
 
+### Service Principal Creation
+The deployment process will offer to create a service principal for you if you choose to
+omit the relevant fields. If you would like to create the service principal and specify the
+credentials manually, you may do so. You'll want to make sure your Azure CLI is configured for
+the same subscription as you're planning to deploy into.
+
+```shell
+wget https://raw.githubusercontent.com/kubernetes/kubernetes-anywhere/master/phase1/azure/create-azure-service-principal.sh -O ./create-azure-service-principal.sh
+chmod +x ./create-azure-service-principal.sh
+./create-azure-service-principal.sh \
+	--subscription-id=<your subscription id> \
+	--name=<whatever name you want> \
+	--app-url=<the client_id> \
+	--secret=<the client_secret> \
+	--output-format=text
+```

--- a/phase1/azure/create-azure-service-principal.sh
+++ b/phase1/azure/create-azure-service-principal.sh
@@ -1,68 +1,123 @@
 #!/bin/bash
-# exit on errors
-set -e
 
-if ! which jq > /dev/null; then
-    echo "Can not find the 'jq' program, please install it"
-    exit 1
+set -eu -o pipefail
+
+## TODO: implement RG scoped auth
+
+## options
+while :; do
+	case ${1:-} in
+		--subscription-id=?*)
+			subscription_id=${1#*=}
+			;;
+		--subscription-id=)
+			printf 'ERROR: "--subscription-id" requires a non-empty option argument.\n' >&2
+			exit 1
+			;;
+		--name=?*)
+			app_name=${1#*=}
+			;;
+		--name=)
+			printf 'ERROR: "--name" requires a non-empty option argument.\n' >&2
+			exit 1
+			;;
+		--app-url=?*)
+			app_url=${1#*=}
+			;;
+		--app-url=)
+			printf 'ERROR: "--app-url" requires a non-empty option argument.\n' >&2
+			exit 1
+			;;
+		--secret=?*)
+			client_secret=${1#*=}
+			;;
+		--secret=)
+			printf 'ERROR: "--secret" requires a non-empty option argument.\n' >&2
+			exit 1
+			;;
+		--location=?*)
+			location=${1#*=}
+			;;
+		--location=)
+			printf 'ERROR: "--location" requires a non-empty option argument.\n' >&2
+			exit
+			;;
+		--resource-group=?*)
+			printf 'ERROR: "--resource-group" is not currently implmented.' >&2
+			exit 1
+			;;
+		--resource-group=)
+			printf 'ERROR: "--resource-group" is not currently implmented.' >&2
+			#printf 'ERROR: "--resource-group" requires a non-empty option argument.\n' >&2
+			exit 1
+			;;
+		--output-format=?*)
+			output_format=${1#*=}
+			;;
+		--output-format=)
+			printf 'ERROR: "--output_format" requires a non-empty option argument.\n' >&2
+			exit 1
+			;;
+		--)
+			shift
+			break
+			;;
+		-?*)
+			printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+			;;
+		*)
+			break
+	esac
+
+	shift
+done
+
+[[ ! -z "${subscription_id:-}" ]] || (printf 'ERROR: "--subscription-id" required.\n' >&2 && exit 1)
+[[ ! -z "${app_url:-}" ]] || (printf 'ERROR: "--app-url" required.\n' >&2 && exit)
+[[ ! -z "${client_secret:-}" ]] || (printf 'ERROR: "--client_secret" required.\n' >&2 && exit)
+
+if [[ ! -z "${resource_group:-}" && -z "${location:-}" ]]; then
+	printf 'ERROR: "--location" required when "--resource-group is specified.\n' >&2 && exit
 fi
 
-if ! which azure > /dev/null; then
-    echo "Can not find the 'azure' command line tools, please install them"
-    exit 1
-fi
+## requirements
+which jq >/dev/null || (printf "Can not find the 'jq' program, please install it.\n" >&2 && exit 1)
+which azure >/dev/null || (printf "Can not find the 'azure' program, please install it.\n" >&2 exit 1)
 
-# get the tenant and subscription id
-tenant_id=$(azure account show --json | jq ".[] | .tenantId")
-sub_id=$(azure account show --json | jq ".[] | .id")
-
-# setup the app
-echo Please enter your application name:
-read app_name
-
-echo Please enter your application url, can be bogus:
-read app_url
-
-echo Please enter your application secret:
-read -s client_secret
-
-echo Please enter your application secret again:
-read -s client_secret_2
-
-if [[ "${client_secret}" != "${client_secret_2}" ]]; then
-    echo "Secrets do not match!"
-    exit 1
-fi
+## ensure logged in
+azure account show &>/dev/null || azure login
+tenant_id=$(azure account show --json | jq -r ".[] | .tenantId")
 
 raw_json=$(azure ad app create -n ${app_name} -i ${app_url} --home-page ${app_url} -p ${client_secret} --json)
+app_id=$(echo $raw_json | jq -r '.appId')
 
-sleep 5
+## Create the service principal
+azure ad sp create --applicationId ${app_id} >/dev/null
 
-echo ${raw_json}
+## Create the role assignment for the service principal
+duration=5
+elapsed=0
+while true; do
+	# TODO: backoff
+	if azure role assignment create --spn ${app_url} -o "Owner" -c /subscriptions/${subscription_id} &>/dev/null ; then
+		break
+	fi
+	# eventual consistency ftw!
+	printf "WARNING: Role assignment failed. Waiting to retry role assignment. (elapsed: ${elapsed})\n" >&2
+	sleep ${duration}
+	elapsed=$((${elapsed} + ${duration}))
+done
 
-app_id=$(echo $raw_json | jq ".appId")
-
-# strip quotes
-app_id="${app_id%\"}"
-app_id="${app_id#\"}"
-sub_id="${sub_id%\"}"
-sub_id="${sub_id#\"}"
-
-# Create the service principal
-azure ad sp create --applicationId ${app_id} --json
-
-# eventual consistency ftw!
-sleep 5
-
-# Create the role assignment for the service principal
-azure role assignment create --spn ${app_url} -o "Owner" -c /subscriptions/${sub_id}
-
-echo Here are the parameters to paste into your config
-echo
-
-echo phase1.azure.tenant_id = "${tenant_id}"
-echo phase1.azure.subscription_id = "\"${sub_id}\""
-echo phase1.azure.client_id = "\"${app_id}\""
-echo phase1.azure.client_secret = "${client_secret}"
-
-
+## Output
+case "${output_format:-}" in
+	"json")
+		output=".tenant_id=\"${tenant_id}\"|.subscription_id=\"${subscription_id}\"|.client_id=\"${app_url}\"|.client_secret=\"${client_secret}\""
+		jq -n "${output}"
+		;;
+	"text")
+		echo tenant_id = "${tenant_id}"
+		echo subscription_id = "${subscription_id}"
+		echo client_id = "\"${app_url}\""
+		echo client_secret = "${client_secret}"
+		;;
+esac

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -3,16 +3,67 @@
 set -o errexit
 set -o pipefail
 set -o nounset
-set -x
 
 cd "${BASH_SOURCE%/*}"
+f="./../../.config.json"
 
 gen() {
   mkdir -p .tmp/
   jsonnet -J ../../ --multi .tmp/ all.jsonnet
 }
 
+check_auth() {
+  cluster_name="$(jq -r '.phase1.cluster_name' $f)"
+  location="$(jq -r '.phase1.azure.location' $f)"
+  subscription_id="$(jq -r '.phase1.azure.subscription_id' $f)"
+  tenant_id="$(jq -r '.phase1.azure.tenant_id' $f)"
+  client_id="$(jq -r '.phase1.azure.client_id' $f)"
+  client_secret="$(jq -r '.phase1.azure.client_secret' $f)"
+
+  if [[ -z "${tenant_id:-}" ]]; then
+    tenant_id="$(curl https://management.azure.com/subscriptions/27b750cd-ed43-42fd-9044-8d75e124ae55?api-version=2016-01-01 -s -D - -o /dev/null | grep WWW-Authenticate | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)"
+  fi
+
+  if [[ -z "${client_id:-}" && -z "${client_secret}" ]]; then
+    app_url="http://${cluster_name}"
+    secret="$(cat /proc/sys/kernel/random/uuid)"
+    while true; do
+    echo
+    echo "Azure 'client_id' and 'client_secret' are empty."
+    echo "This will now create a ServicePrincipal named '${cluster_name}', identified by '${app_url}' which will be granted 'Contributor' access to the specific subscription."
+    read -p "Proceed and create new ServicePrincipal? [y/n] " -n 1 -r && echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      ./create-azure-service-principal.sh \
+        --subscription-id=${subscription_id} \
+        --name="${cluster_name}" \
+        --secret="${secret}" \
+        --app-url="${app_url}" \
+        --output-format=text
+
+	  sed -i "s|.phase1.azure.client_id=\"\"|.phase1.azure.client_id=\"${app_url}\"|" "$f"
+	  sed -i "s|.phase1.azure.client_secret=\"\"|.phase1.azure.client_secret=\"${secret}\"|" "$f"
+	  sed -i "s|.phase1.azure.tenant_id=\"\"|.phase1.azure.tenant_id=\"${client_id}\"|" "$f"
+
+      gened="{\"phase1\":{\"azure\":{\
+          \"client_id\": \"${app_url}\",\
+          \"client_secret\": \"${secret}\",\
+          \"tenant_id\": \"${tenant_id}\"\
+      }}}"
+
+      merged="$(jq ". * ${gened}" ../../.config.json)"
+      echo "${merged}" > ../../.config.json.tmp
+      mv ../../.config.json{.tmp,}
+      break
+    elif [[ $REPLY =~ ^[Nn]$ ]]; then
+      printf 'Credentials must be supplied.' >&2
+      exit -1
+    fi
+    done
+  fi
+}
+
 deploy() {
+  check_auth
   gen
 
   # validate the config

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -3,7 +3,7 @@ menu "Phase 2: Node Bootstrapping"
 
 config phase2.installer_container
 	string "installer container"
-	default "docker.io/colemickens/install-k8s:v1"
+	default "docker.io/colemickens/k8s-ignition:latest"
 
 config phase2.docker_registry
 	string "docker registry"
@@ -13,7 +13,7 @@ config phase2.docker_registry
 
 config phase2.kubernetes_version
 	string "kubernetes version"
-	default "v1.2.4"
+	default "v1.4.0-alpha.2"
 	help
 	  The version of Kubernetes to deploy.
 

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -13,7 +13,7 @@ config phase2.docker_registry
 
 config phase2.kubernetes_version
 	string "kubernetes version"
-	default "v1.4.0-alpha.2"
+	default "v1.4.0-alpha.3"
 	help
 	  The version of Kubernetes to deploy.
 

--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -eux -o pipefail
 
-apk add --update git build-base wget jq autoconf automake pkgconfig ncurses libtool gperf flex bison ca-certificates
+apk add --update git build-base wget curl jq autoconf automake pkgconfig ncurses libtool gperf flex bison ca-certificates
 
 ## Install kubectl
-export KUBECTL_VERSION=1.3.5
+export KUBECTL_VERSION=1.3.6
 wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl
 
@@ -17,8 +17,8 @@ cp jsonnet /usr/local/bin)
 rm -rf /tmp/jsonnet
 
 ## Install Terraform
-export TERRAFORM_VERSION=0.7.1
-export TERRAFORM_SHA256SUM=133766ed558af04255490f135fed17f497b9ba1e277ff985224e1287726ab2dc
+export TERRAFORM_VERSION=0.7.2
+export TERRAFORM_SHA256SUM=b337c885526a8a653075551ac5363a09925ce9cf141f4e9a0d9f497842c85ad5
 
 mkdir -p /tmp/terraform/
 (cd /tmp/terraform
@@ -34,7 +34,6 @@ npm install -g azure-cli
 
 ## Install kconfig-conf
 export KCONFIG_VERSION=4.7.0.0
-#apt-get update && apt-get install -y autoconf automake pkg-config gperf libtool flex bison libncurses5-dev \
 mkdir -p /tmp/kconfig-frontends
 (cd /tmp/kconfig-frontends
 git clone "https://github.com/colemickens/kconfig-frontends" .


### PR DESCRIPTION
The PR does a few things:

1. Fixes a small bug in `Makefile` introduced when I rearranged the `make deploy` command.

2. Upgrades `terraform`, adds `curl` to the docker environment, removes a defunct comment.

3. Rearranges the Azure phase1 `Kconfig` so the user can input `subscription_id` first off and then spam `<enter>` for all the other questions.

4. Changes the defaults in phase2 to point to an ignition container that I'm updating and to point to the latest `1.4.0-alpha.3` build of Kube 1.4.x.

5. **Automatic** creation of a service principal for Azure. This changes the `create-azure-service-principal.sh` script in a few ways:

  * (`do`)  Will notice that the `tenant_id` field is empty and will automatically infer it based on the `subscription_id`.
  * (`do`)  Will notice that the `client_id`/`client_secret` fields are empty and offer to create creds
  * (`create-azure-service-principal.sh`) Accepts command line arguments instead of being interactive
  * (`create-azure-service-principal.sh`) Will automatically retry if the role assignment fails. (It does not backoff yet)
  * (`do`)  Will backfill both `.config` and `.config.json`.

The SP created will have Subscription level access by default. The user is warned of this in `./do` so they can consent or can refuse and stop the deployment.

**The net result:** The user only needs to know their subscription ID in order to do this deployment. They don't need to pre-provision a ServicePrincipal (unless they don't have permission to create a new SP, in which case they need to get a more privileged user to make them one)