### PR TITLE
azure: fix tenant_id auto-detection and back-filling

### DIFF
--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -21,7 +21,7 @@ check_auth() {
   client_secret="$(jq -r '.phase1.azure.client_secret' $f)"
 
   if [[ -z "${tenant_id:-}" ]]; then
-    tenant_id="$(curl https://management.azure.com/subscriptions/27b750cd-ed43-42fd-9044-8d75e124ae55?api-version=2016-01-01 -s -D - -o /dev/null | grep WWW-Authenticate | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)"
+    tenant_id="$(curl https://management.azure.com/subscriptions/${subscriptions}?api-version=2016-01-01 -s -D - -o /dev/null | grep WWW-Authenticate | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)"
   fi
 
   if [[ -z "${client_id:-}" && -z "${client_secret}" ]]; then

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -5,7 +5,8 @@ set -o pipefail
 set -o nounset
 
 cd "${BASH_SOURCE%/*}"
-f="./../../.config.json"
+config="./../../.config"
+configjson="./../../.config.json"
 
 gen() {
   mkdir -p .tmp/
@@ -13,15 +14,15 @@ gen() {
 }
 
 check_auth() {
-  cluster_name="$(jq -r '.phase1.cluster_name' $f)"
-  location="$(jq -r '.phase1.azure.location' $f)"
-  subscription_id="$(jq -r '.phase1.azure.subscription_id' $f)"
-  tenant_id="$(jq -r '.phase1.azure.tenant_id' $f)"
-  client_id="$(jq -r '.phase1.azure.client_id' $f)"
-  client_secret="$(jq -r '.phase1.azure.client_secret' $f)"
+  cluster_name="$(jq -r '.phase1.cluster_name' ${configjson})"
+  location="$(jq -r '.phase1.azure.location' ${configjson})"
+  subscription_id="$(jq -r '.phase1.azure.subscription_id' ${configjson})"
+  tenant_id="$(jq -r '.phase1.azure.tenant_id' ${configjson})"
+  client_id="$(jq -r '.phase1.azure.client_id' ${configjson})"
+  client_secret="$(jq -r '.phase1.azure.client_secret' ${configjson})"
 
   if [[ -z "${tenant_id:-}" ]]; then
-    tenant_id="$(curl https://management.azure.com/subscriptions/${subscriptions}?api-version=2016-01-01 -s -D - -o /dev/null | grep WWW-Authenticate | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)"
+    tenant_id="$(curl https://management.azure.com/subscriptions/${subscription_id}?api-version=2016-01-01 -s -D - -o /dev/null | grep WWW-Authenticate | egrep '[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}' -o)"
   fi
 
   if [[ -z "${client_id:-}" && -z "${client_secret}" ]]; then
@@ -40,9 +41,9 @@ check_auth() {
         --app-url="${app_url}" \
         --output-format=text
 
-	  sed -i "s|.phase1.azure.client_id=\"\"|.phase1.azure.client_id=\"${app_url}\"|" "$f"
-	  sed -i "s|.phase1.azure.client_secret=\"\"|.phase1.azure.client_secret=\"${secret}\"|" "$f"
-	  sed -i "s|.phase1.azure.tenant_id=\"\"|.phase1.azure.tenant_id=\"${client_id}\"|" "$f"
+      sed -i "s|.phase1.azure.client_id=\"\"|.phase1.azure.client_id=\"${app_url}\"|" "${config}"
+      sed -i "s|.phase1.azure.client_secret=\"\"|.phase1.azure.client_secret=\"${secret}\"|" "${config}"
+      sed -i "s|.phase1.azure.tenant_id=\"\"|.phase1.azure.tenant_id=\"${tenant_id}\"|" "${config}"
 
       gened="{\"phase1\":{\"azure\":{\
           \"client_id\": \"${app_url}\",\
@@ -50,9 +51,9 @@ check_auth() {
           \"tenant_id\": \"${tenant_id}\"\
       }}}"
 
-      merged="$(jq ". * ${gened}" ../../.config.json)"
-      echo "${merged}" > ../../.config.json.tmp
-      mv ../../.config.json{.tmp,}
+      merged="$(jq ". * ${gened}" "${configjson}")"
+      echo "${merged}" > "${configjson}.tmp"
+      mv "${configjson}.tmp" "${configjson}"
       break
     elif [[ $REPLY =~ ^[Nn]$ ]]; then
       printf 'Credentials must be supplied.' >&2


### PR DESCRIPTION
1. Had accidentally hard-coded my subscription ID, meaning all users would've gotten the MS tenant ID if they were using the automatic SP creation script. No information risk, but it wouldn't have worked for them.

2. The backfilling of the config files wasn't being done correctly, causing the user to need to run `make deploy` twice.

Both of these issues are resolved with this PR.