### PR TITLE
azure: fix kubeconfig mkdir instructions

### DIFF
--- a/phase1/azure/README.md
+++ b/phase1/azure/README.md
@@ -62,7 +62,7 @@ Let's copy your `kubeconfig.json` file somewhere for safe-keeping.
 You'll need to do this outside of the `kubernetes-anywhere` deployment environment so that it is usable later.
 
 ```shell
-mkdir -p ~/.kube/config
+mkdir -p ~/.kube
 cp ./phase1/azure/.tmp/kubeconfig.json ~/.kube/config
 ```
 


### PR DESCRIPTION
The instructions were a bit off and had the user creating `~/.kube/config` as a directory, which resulted in the move placing the edit into a directory such that the file ended up at `~/.kube/config/kubeconfig.json` rather than at `~/.kube/confifg`.

CC: @anhowe This is the issue you mentioned this afternoon.