### PR TITLE
azure : Rebase ephemeral & premium Disks options 

### DIFF
--- a/phase1/azure/Kconfig
+++ b/phase1/azure/Kconfig
@@ -53,6 +53,16 @@ config phase1.azure.node_vm_size
 	help
 		The size of VirtualMachine to deploy.
 
+config phase1.azure.use_premium_storage
+	bool "Whether or not to use premium storage"
+	help
+		Whether or not to use Premium_LRS as a storage account
+
+config phase1.azure.use_ephemeral_drive
+	bool "Whether or not to use ephemeral drive"
+	help
+		Whether or not to mount the ephmeral drive at /var/lib/docker 
+
 config phase1.azure.master_private_ip
 	string "Private IP address of Master"
 	default "10.240.1.4"

--- a/phase1/azure/Kconfig
+++ b/phase1/azure/Kconfig
@@ -54,13 +54,15 @@ config phase1.azure.node_vm_size
 		The size of VirtualMachine to deploy.
 
 config phase1.azure.use_premium_storage
-	bool "Whether or not to use premium storage"
+	string "Whether or not to use premium storage [yes/no]"
+        default "yes"
 	help
 		Whether or not to use Premium_LRS as a storage account
 
 config phase1.azure.use_ephemeral_drive
-	bool "Whether or not to use ephemeral drive"
-	help
+	string "Whether or not to use ephemeral drive [yes/no]"
+	default "yes"
+        help
 		Whether or not to mount the ephmeral drive at /var/lib/docker 
 
 config phase1.azure.master_private_ip

--- a/phase1/azure/azure.jsonnet
+++ b/phase1/azure/azure.jsonnet
@@ -1,8 +1,8 @@
 function(config)
   local tf = import "phase1/tf.jsonnet";
   local cfg = config.phase1;
-  local master_private_ip = cfg.azure.master_private_ip;
-  local storage_type = if cfg.azure.use_premium_storage then "Premium_LRS" else "Standard_LRS";
+  local master_private_ip = cfg.azure.master_private_ip; 
+  local storage_type = if cfg.azure.use_premium_storage == "yes" then "Premium_LRS" else "Standard_LRS";
   local names = {
     resource_group: "%(cluster_name)s" % cfg,
     master_public_ip: "%(cluster_name)s-master-pip" % cfg,

--- a/phase1/azure/azure.jsonnet
+++ b/phase1/azure/azure.jsonnet
@@ -2,6 +2,7 @@ function(config)
   local tf = import "phase1/tf.jsonnet";
   local cfg = config.phase1;
   local master_private_ip = cfg.azure.master_private_ip;
+  local storage_type = if cfg.azure.use_premium_storage then "Premium_LRS" else "Standard_LRS";
   local names = {
     resource_group: "%(cluster_name)s" % cfg,
     master_public_ip: "%(cluster_name)s-master-pip" % cfg,
@@ -86,7 +87,7 @@ function(config)
           resource_group_name: "${azurerm_resource_group.rg.name}",
           name: names.storage_account,
           location: "${azurerm_resource_group.rg.location}",
-          account_type: "Standard_LRS",
+          account_type: storage_type,
         },
       },
       azurerm_storage_container: {
@@ -280,3 +281,4 @@ function(config)
       },
     },
   }, tf.pki.cluster_tls(cfg.cluster_name, [names.master_vm], ["${azurerm_public_ip.pip.ip_address}", master_private_ip]))
+

--- a/phase1/azure/configure-vm.sh
+++ b/phase1/azure/configure-vm.sh
@@ -64,3 +64,8 @@ docker run \
 
 systemctl enable kubelet
 systemctl start kubelet
+
+systemctl enable var-lib-docker.mount
+systemctl enable format-ephemeral.service
+
+reboot

--- a/phase2/ignition/vanilla/node.jsonnet
+++ b/phase2/ignition/vanilla/node.jsonnet
@@ -6,16 +6,19 @@ function(cfg)
     ignition: { version: "2.0.0" },
     systemd: {
       units: [
-        {
-          name: "format-ephemeral.service",
-          enable: true,
-          contents: (importstr "tasks/format-ephemeral.service"),
-        },
-	{
-          name: "var-lib-docker.mount",
-          enable: true,
-          contents: (importstr "tasks/var-lib-docker.mount"),
-        },
+        if phase1.azure.use_ephemeral_drive == "yes" then
+          [
+            {
+              name: "format-ephemeral.service",
+              enable: true,
+              contents: (importstr "tasks/format-ephemeral.service"),
+            },
+	    {
+              name: "var-lib-docker.mount",
+              enable: true,
+              contents: (importstr "tasks/var-lib-docker.mount"),
+            },
+          ],
         {
           name: "kubelet.service",
           enable: true,

--- a/phase2/ignition/vanilla/node.jsonnet
+++ b/phase2/ignition/vanilla/node.jsonnet
@@ -5,43 +5,55 @@ function(cfg)
     local util = import "util.jsonnet",
     ignition: { version: "2.0.0" },
     systemd: {
-      units: [{
-        name: "kubelet.service",
-        enable: true,
-        contents: (importstr "kubelet.service") % {
-          docker_registry: phase2.docker_registry,
-          kubernetes_version: phase2.kubernetes_version,
-          kubelet_args: std.join(" ", util.build_params([
-            [
-              "--address=0.0.0.0",
-              "--allow-privileged=true",
-              "--cloud-provider=" + phase1.cloud_provider,
-              "--enable-server",
-              "--enable-debugging-handlers",
-              "--kubeconfig=/srv/kubernetes/kubeconfig.json",
-              "--config=/etc/kubernetes/manifests",
-              "--cluster-dns=10.0.0.10",
-              "--cluster-domain=cluster.local",
-              "--v=2",
-            ],
-            if cfg.role == "node" then
-              [
-                "--api-servers=https://" + cfg.master_ip,
-                "--hairpin-mode=promiscuous-bridge",
-                "--network-plugin=kubenet",
-                "--reconcile-cidr",
-              ]
-            else
-              [
-                "--api-servers=http://localhost:8080",
-                "--register-schedulable=false",
-              ],
-            if phase1.cloud_provider == "azure" then
-              [
-                "--cloud-config=/etc/kubernetes/azure.json",
-              ],
-          ])),
+      units: [
+        {
+          name: "format-ephemeral.service",
+          enable: true,
+          contents: (importstr "tasks/format-ephemeral.service")
         },
-      }],
-    },
+	{
+          name: "var-lib-docker.mount",
+          enable: true,
+          contents: (importstr "tasks/var-lib-docker.mount")
+        },
+        {
+          name: "kubelet.service",
+          enable: true,
+          contents: (importstr "kubelet.service") % {
+            docker_registry: phase2.docker_registry,
+            kubernetes_version: phase2.kubernetes_version,
+            kubelet_args: std.join(" ", util.build_params([
+              [
+                "--address=0.0.0.0",
+                "--allow-privileged=true",
+                "--cloud-provider=" + phase1.cloud_provider,
+                "--enable-server",
+                "--enable-debugging-handlers",
+                "--kubeconfig=/srv/kubernetes/kubeconfig.json",
+                "--config=/etc/kubernetes/manifests",
+                "--cluster-dns=10.0.0.10",
+                "--cluster-domain=cluster.local",
+                "--v=2",
+              ],
+              if cfg.role == "node" then
+                [
+                  "--api-servers=https://" + cfg.master_ip,
+                  "--hairpin-mode=promiscuous-bridge",
+                  "--network-plugin=kubenet",
+                  "--reconcile-cidr",
+                ]
+              else
+                [
+                  "--api-servers=http://localhost:8080",
+                  "--register-schedulable=false",
+                ],
+              if phase1.cloud_provider == "azure" then
+                [
+                  "--cloud-config=/etc/kubernetes/azure.json",
+                ]
+            ]))
+          }
+        }       
+      ]
+    }
   }

--- a/phase2/ignition/vanilla/node.jsonnet
+++ b/phase2/ignition/vanilla/node.jsonnet
@@ -9,12 +9,12 @@ function(cfg)
         {
           name: "format-ephemeral.service",
           enable: true,
-          contents: (importstr "tasks/format-ephemeral.service")
+          contents: (importstr "tasks/format-ephemeral.service"),
         },
 	{
           name: "var-lib-docker.mount",
           enable: true,
-          contents: (importstr "tasks/var-lib-docker.mount")
+          contents: (importstr "tasks/var-lib-docker.mount"),
         },
         {
           name: "kubelet.service",

--- a/phase2/ignition/vanilla/tasks/format-ephemeral.service
+++ b/phase2/ignition/vanilla/tasks/format-ephemeral.service
@@ -4,8 +4,6 @@ Documentation=https://coreos.com/os/docs/latest/mounting-storage.html
 
 [Service]
 Type=oneshot
-RemainAfterExit=yes
-ExecStart=systemctl start var-lib-docker.mount
 ExecStart=/bin/bash -c -x "umount -f /mnt/resource || /bin/true"
 ExecStart=/bin/bash -c -x "umount -A /dev/sdb1 || /bin/true"
 ExecStart=/bin/bash -c -x "umount -A /dev/sdb || /bin/true"

--- a/phase2/ignition/vanilla/tasks/format-ephemeral.service
+++ b/phase2/ignition/vanilla/tasks/format-ephemeral.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Format Ephemeral Volume
+Documentation=https://coreos.com/os/docs/latest/mounting-storage.html
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=systemctl start var-lib-docker.mount
+ExecStart=/bin/bash -c -x "umount -f /mnt/resource || /bin/true"
+ExecStart=/bin/bash -c -x "umount -A /dev/sdb1 || /bin/true"
+ExecStart=/bin/bash -c -x "umount -A /dev/sdb || /bin/true"
+ExecStart=/bin/bash -c -x "rm -rf /mnt/resource"
+ExecStart=/bin/bash -c -x "wipefs -f /dev/sdb1 || true"
+ExecStart=/bin/bash -c -x "mkfs.ext4 -F /dev/sdb"
+
+[Install]
+WantedBy=multi-user.target

--- a/phase2/ignition/vanilla/tasks/format-ephemeral.service
+++ b/phase2/ignition/vanilla/tasks/format-ephemeral.service
@@ -1,6 +1,9 @@
 [Unit]
 Description=Format Ephemeral Volume
 Documentation=https://coreos.com/os/docs/latest/mounting-storage.html
+Before=docker.service var-lib-docker.mount
+After=dev-sdb.device
+Requires=dev-sdb.device
 
 [Service]
 Type=oneshot
@@ -12,4 +15,4 @@ ExecStart=/bin/bash -c -x "wipefs -f /dev/sdb1 || true"
 ExecStart=/bin/bash -c -x "mkfs.ext4 -F /dev/sdb"
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=var-lib-docker.mount

--- a/phase2/ignition/vanilla/tasks/var-lib-docker.mount
+++ b/phase2/ignition/vanilla/tasks/var-lib-docker.mount
@@ -11,4 +11,3 @@ Type=ext4
 
 [Install]
 WantedBy=local-fs.target
-

--- a/phase2/ignition/vanilla/tasks/var-lib-docker.mount
+++ b/phase2/ignition/vanilla/tasks/var-lib-docker.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mount /var/lib/docker on SSD Ephemeral
+Documentation=https://coreos.com/os/docs/latest/mounting-storage.html
+After=format-ephemeral.service
+Requires=format-ephemeral.service
+
+[Mount]
+What=/dev/sdb
+Where=/var/lib/docker
+Type=ext4
+
+[Install]
+WantedBy=local-fs.target
+

--- a/phase2/ignition/vanilla/tasks/var-lib-docker.mount
+++ b/phase2/ignition/vanilla/tasks/var-lib-docker.mount
@@ -1,6 +1,7 @@
 [Unit]
 Description=Mount /var/lib/docker on SSD Ephemeral
 Documentation=https://coreos.com/os/docs/latest/mounting-storage.html
+Before=docker.service
 After=format-ephemeral.service
 Requires=format-ephemeral.service
 
@@ -10,4 +11,4 @@ Where=/var/lib/docker
 Type=ext4
 
 [Install]
-WantedBy=local-fs.target
+RequiredBy=docker.service


### PR DESCRIPTION
Hello guys,

@colemickens @mikedanese 

I rebased a little bit the Cole's PR about implementation of ephemeral and premium disks on Azure. I need to work a little bit on it so please DO NOT MERGE for the moment ;)

Some points that are not working for the moment : 
- Implementation of `cfg.phase1.azure.use_premium_storage` and `cfg.phase1.azure.use_ephemeral_drive` was made with a `String` type with choice : `yes` or `no`. Actually the condition :  

>  local storage_type = if cfg.azure.use_premium_storage == "yes" then "Premium_LRS" else "Standard_LRS";

into `azure.jsonnet` is not working with a `bool` type if is setted on "n". The line is commented into the `.config` ...
- The condition `if` into the `phase2/ignition/vanilla/node.jsonnet` is not working properly, i'm not an expert in `jsonnet` and actually if i hit the condition by putting `cfg.phase1.azure.use_ephemeral_drive == yes` the Ignition init crashed on the nodes and throw an error. My `if` condition is certainly badly placed ... 

@mikedanese  you did something similar in the phase3, with `bool` type (addons) but i wasn't able to make it works on the phase1 for Azure. Terraform is still dropping an error saying that `use_ephemeral_drive` is not defined or missing. Cole thinked about a specific problem into Kconfig-conf, but since i saw that you handled it into phase3 maybe that you have the solution.

By the way, use_premium_storage is working properly, the rest needs just some fixes.

Waiting for your review guys, 

Cheers, 
Théo
