### PR TITLE
Update kubernetes, heapster, kube-proxy, kube-dns

### DIFF
--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -13,7 +13,7 @@ config phase2.docker_registry
 
 config phase2.kubernetes_version
 	string "kubernetes version"
-	default "v1.4.0-beta.3"
+	default "v1.4.0"
 	help
 	  The version of Kubernetes to deploy.
 

--- a/phase3/heapster/heapster-deployment.json
+++ b/phase3/heapster/heapster-deployment.json
@@ -6,7 +6,7 @@
       "spec": {
         "containers": [
           {
-            "image": "gcr.io/google_containers/heapster:v1.2.0-beta.1",
+            "image": "gcr.io/google_containers/heapster:v1.2.0",
             "command": [
               "/heapster",
               "--source=kubernetes.summary_api:''"
@@ -24,7 +24,7 @@
             }
           },
           {
-            "image": "gcr.io/google_containers/addon-resizer:1.3",
+            "image": "gcr.io/google_containers/addon-resizer:1.6",
             "command": [
               "/pod_nanny",
               "--cpu=80m",
@@ -72,7 +72,7 @@
       "metadata": {
         "labels": {
           "k8s-app": "heapster",
-          "version": "v1.2.0-beta.1"
+          "version": "v1.2.0"
         },
         "annotations": {
           "scheduler.alpha.kubernetes.io/critical-pod": "",
@@ -83,7 +83,7 @@
     "selector": {
       "matchLabels": {
         "k8s-app": "heapster",
-        "version": "v1.2.0-beta.1"
+        "version": "v1.2.0"
       }
     }
   },
@@ -91,10 +91,10 @@
   "metadata": {
     "labels": {
       "k8s-app": "heapster",
-      "version": "v1.2.0-beta.1",
+      "version": "v1.2.0",
       "kubernetes.io/cluster-service": "true"
     },
     "namespace": "kube-system",
-    "name": "heapster-v1.2.0-beta.1"
+    "name": "heapster-v1.2.0"
   }
 }

--- a/phase3/kube-dns/kube-dns-deployment.json
+++ b/phase3/kube-dns/kube-dns-deployment.json
@@ -11,7 +11,7 @@
               "successThreshold": 1,
               "initialDelaySeconds": 60,
               "httpGet": {
-                "path": "/healthz",
+                "path": "/healthz-kubedns",
                 "scheme": "HTTP",
                 "port": 8080
               },
@@ -28,7 +28,7 @@
               },
               "timeoutSeconds": 5
             },
-            "image": "gcr.io/google_containers/kubedns-amd64:1.6",
+            "image": "gcr.io/google_containers/kubedns-amd64:1.7",
             "args": [
               "--domain=cluster.local.",
               "--dns-port=10053"
@@ -51,7 +51,6 @@
                 "memory": "70Mi"
               },
               "limits": {
-                "cpu": "100m",
                 "memory": "170Mi"
               }
             }
@@ -61,7 +60,8 @@
             "args": [
               "--cache-size=1000",
               "--no-resolv",
-              "--server=127.0.0.1#10053"
+              "--server=127.0.0.1#10053",
+              "--log-facility=-"
             ],
             "name": "dnsmasq",
             "ports": [
@@ -78,12 +78,26 @@
             ]
           },
           {
-            "image": "gcr.io/google_containers/exechealthz-amd64:1.1",
+            "image": "gcr.io/google_containers/exechealthz-amd64:1.2",
             "args": [
-              "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null",
-              "-port=8080",
-              "-quiet"
+              "--cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null",
+              "--url=/healthz-dnsmasq",
+              "--cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null",
+              "--url=/healthz-kubedns",
+              "--port=8080",
+              "--quiet"
             ],
+            "livenessProbe": {
+              "successThreshold": 1,
+              "initialDelaySeconds": 60,
+              "httpGet": {
+                "path": "/healthz-dnsmasq",
+                "scheme": "HTTP",
+                "port": 8080
+              },
+              "timeoutSeconds": 5,
+              "failureThreshold": 5
+            },
             "name": "healthz",
             "resources": {
               "requests": {
@@ -91,7 +105,6 @@
                 "memory": "50Mi"
               },
               "limits": {
-                "cpu": "10m",
                 "memory": "50Mi"
               }
             },
@@ -125,8 +138,7 @@
   "metadata": {
     "labels": {
       "k8s-app": "kube-dns",
-      "version": "v19",
-      "kubernetes.io/cluster-service": "true"
+      "version": "v19"
     },
     "namespace": "kube-system",
     "name": "kube-dns-v19"

--- a/phase3/kube-proxy/kube-proxy-ds.jsonnet
+++ b/phase3/kube-proxy/kube-proxy-ds.jsonnet
@@ -39,7 +39,7 @@ function(cfg)
                   name: "ssl-certs-host",
                 },
                 {
-                  readOnly: false,
+                  readOnly: true,
                   mountPath: "/srv/kubernetes/kubeconfig.json",
                   name: "kubeconfig",
                 },

--- a/phase3/kube-proxy/kube-proxy-ds.jsonnet
+++ b/phase3/kube-proxy/kube-proxy-ds.jsonnet
@@ -30,7 +30,6 @@ function(cfg)
                 "/hyperkube",
                 "proxy",
                 "--kubeconfig=/srv/kubernetes/kubeconfig.json",
-                "--resource-container=\"\"",
               ],
               image: "%(docker_registry)s/hyperkube-amd64:%(kubernetes_version)s" % cfg.phase2,
               volumeMounts: [

--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 apk add --update git build-base wget curl jq autoconf automake pkgconfig ncurses libtool gperf flex bison ca-certificates
 
 ## Install kubectl
-export KUBECTL_VERSION=1.3.6
+export KUBECTL_VERSION=1.4.0
 wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
1. Phase2: Default to `1.4.0` final.

2. Addons: DNS: Mirror upstream changes

3. Addons: Kube-Proxy: Remove deprecated flag

4. Addons: Kube-Proxy: kubeconfig volume should be read-only

5. Addons: Heapster: switch to `1.2.0` final.
