### PR TITLE
azure: extend wait for AAD consistency

### DIFF
--- a/phase1/azure/README.md
+++ b/phase1/azure/README.md
@@ -53,6 +53,16 @@ make deploy
   * phase1.azure.client_secret
   ```
 
+* If you see this error output, please wait a minute and re-execute `make deploy`. This is a known issue due to some Azure AD interactions.
+
+  ```
+  Error refreshing state: 1 error(s) occurred:
+
+  * Credentials for acessing the Azure Resource Manager API are likely to be incorrect, or
+    the service principal does not have permission to use the Azure Service Management
+    API.
+  ```
+
 ## Congratulations!
 
 You have a Kubernetes cluster!

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -55,8 +55,8 @@ check_auth() {
       echo "${merged}" > "${configjson}.tmp"
       mv "${configjson}.tmp" "${configjson}"
 
-      echo "Sleeping for 10 seconds to prevent Terraform failures"
-      sleep 10
+      echo "Sleeping for 30 seconds to prevent Terraform failures"
+      sleep 30
 
       break
     elif [[ $REPLY =~ ^[Nn]$ ]]; then


### PR DESCRIPTION
1. Wait 30 seconds instead of 10 to workaround AAD propagation delays.

2. Document this failure case and workaround.