### PR TITLE
azure: add storage_name param, autogen if blank

### DIFF
--- a/phase1/azure/Kconfig
+++ b/phase1/azure/Kconfig
@@ -45,7 +45,7 @@ config phase1.azure.image_version
 config phase1.azure.storage_account_name
 	string "Azure Storage Account Name"
 	help
-		The name of the storage account to store VHDs in. version of the base image used for the VirtualMachines. (If left blank, a random name will be generated)
+		The name of the storage account to store VHDs in. (If left blank, a random name will be generated)
 
 config phase1.azure.master_vm_size
 	string "Virtual Machine Size (Master)"

--- a/phase1/azure/Kconfig
+++ b/phase1/azure/Kconfig
@@ -8,17 +8,17 @@ config phase1.azure.subscription_id
 config phase1.azure.tenant_id
 	string "Azure TenantID"
 	help
-		The Azure Tenant ID
+		The Azure Tenant ID. (If left blank, will be auto-determined from the Subscription ID)
 
 config phase1.azure.client_id
 	string "Azure Active Directory ServicePrincipal ClientID"
 	help
-		The ClientID of the Service Account to be used by the cluster components.
+		The ClientID of the Service Account to be used by the cluster components. (If left blank, will be created automatically)
 
 config phase1.azure.client_secret
 	string "Azure Active Directory ServicePrincipal ClientSecret"
 	help
-		The ClientSecret of the Service Account to be used by the cluster components.
+		The ClientSecret of the Service Account to be used by the cluster components. (If left blank, will be created automatically)
 
 config phase1.azure.image_publisher
 	string "Base Virtual Machine OS Image"
@@ -35,11 +35,17 @@ config phase1.azure.image_sku
 	default "16.04.0-LTS"
 	help
 		The sku of the base image used for the VirtualMachines.
+
 config phase1.azure.image_version
 	string "Base Virtual Machine OS Image"
 	default "latest"
 	help
 		The version of the base image used for the VirtualMachines.
+
+config phase1.azure.storage_account_name
+	string "Azure Storage Account Name"
+	help
+		The name of the storage account to store VHDs in. version of the base image used for the VirtualMachines. (If left blank, a random name will be generated)
 
 config phase1.azure.master_vm_size
 	string "Virtual Machine Size (Master)"

--- a/phase1/azure/azure.jsonnet
+++ b/phase1/azure/azure.jsonnet
@@ -6,7 +6,7 @@ function(config)
     resource_group: "%(cluster_name)s" % cfg,
     master_public_ip: "%(cluster_name)s-master-pip" % cfg,
     availability_set: "%(cluster_name)s-as" % cfg,
-    storage_account: "${replace(\"%(cluster_name)s\", \"-\", \"\")}" % cfg,
+    storage_account: cfg.azure.storage_account_name,
     storage_container: "strg%(cluster_name)s" % cfg,
     vnet: "%(cluster_name)s-vnet" % cfg,
     subnet: "%(cluster_name)s-subnet" % cfg,

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -73,7 +73,10 @@ check_storage_account_name() {
     # everything is fine, we assume user knows what they are doing
     return 0
   fi
-  set +e; storage_account_name="$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 21 | head -n 1)k8s"; set -e
+  set +e;
+  storage_account_name="$(cat /dev/urandom | tr -dc 'a-z' | fold -w 1 | head -n 1)";
+  storage_account_name="${storage_account_name}$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 20 | head -n 1)k8s"
+  set -e;
 
   sed -i "s|.phase1.azure.storage_account_name=\"\"|.phase1.azure.storage_account_name=\"${storage_account_name}\"|" "${config}"
 

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -67,12 +67,28 @@ check_auth() {
   fi
 }
 
+check_storage_account_name() {
+  storage_account_name="$(jq -r '.phase1.azure.storage_account_name' ${configjson})"
+  if [[ ! -z "${storage_account_name}" ]]; then
+    # everything is fine, we assume user knows what they are doing
+    return 0
+  fi
+  set +e; storage_account_name="$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 21 | head -n 1)k8s"; set -e
+
+  sed -i "s|.phase1.azure.storage_account_name=\"\"|.phase1.azure.storage_account_name=\"${storage_account_name}\"|" "${config}"
+
+  gened="{\"phase1\":{\"azure\":{\
+      \"storage_account_name\": \"${storage_account_name}\"\
+  }}}"
+  merged="$(jq ". * ${gened}" "${configjson}")"
+  echo "${merged}" > "${configjson}.tmp"
+  mv "${configjson}.tmp" "${configjson}"
+}
+
 deploy() {
+  check_storage_account_name
   check_auth
   gen
-
-  # TODO: offer to fill in SP creds
-  # TODO: check storage account name
 
   # Workaround: https://github.com/hashicorp/terraform/issues/7153
   terraform apply -state=./.tmp/terraform.tfstate .tmp ||


### PR DESCRIPTION
1. Add a `storage_name` parameter to `phase1/azure/Kconfig`.

2. Use this field in the Azure Terraform file.

3. In `phase1/azure/do` check, and auto-fill-if-missing the `storage_account_name` similarly to how the TenantID and SP are auto-generated and filled in.

Not terribly pretty, but functional for now and would enable us to remove the "global uniqueness" requirement as it's been a source of confusion.

Please take a look @ahmetalpbalkan, @ggm-at-apnic and let me know what your feedback is.