### PR TITLE
[kubelet.service] Add the mounting of /var/log.

### DIFF
--- a/phase2/ignition/vanilla/kubelet.service
+++ b/phase2/ignition/vanilla/kubelet.service
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/docker run \
         -v /var/run:/var/run:rw \
         -v /var/lib/docker/:/var/lib/docker:rw \
         -v /var/lib/kubelet/:/var/lib/kubelet:shared \
+        -v /var/log:/var/log:shared \
         -v /srv/kubernetes:/srv/kubernetes:ro \
         -v /etc/kubernetes:/etc/kubernetes:ro \
         %(docker_registry)s/hyperkube-amd64:%(kubernetes_version)s \


### PR DESCRIPTION
The mounting of `/var/log` enables necessary log sharing when Fluentd is in play.