### PR TITLE
Add kubeadm support for phase2.

### DIFF
--- a/phase1/gce/configure-vm-ignition.sh
+++ b/phase1/gce/configure-vm-ignition.sh
@@ -1,0 +1,37 @@
+# This is not meant to run on its own, but extends phase1/gce/configure-vm.sh
+
+mkdir -p /etc/kubernetes/
+get_metadata "k8s-config" > /etc/kubernetes/k8s_config.json
+
+mkdir -p /srv/kubernetes
+case "${ROLE}" in
+  "master")
+    get_metadata "k8s-ca-public-key" \
+      > /srv/kubernetes/ca.pem
+    get_metadata "k8s-apisever-public-key" \
+      > /srv/kubernetes/apiserver.pem
+    get_metadata "k8s-apisever-private-key" \
+      > /srv/kubernetes/apiserver-key.pem
+    get_metadata "k8s-master-kubeconfig" \
+      > /srv/kubernetes/kubeconfig.json
+    ;;
+  "node")
+    get_metadata "k8s-node-kubeconfig" \
+      > /srv/kubernetes/kubeconfig.json
+    ;;
+  *)
+    echo "'${ROLE}' is not a valid role"
+    exit 1
+    ;;
+esac
+
+docker run \
+  --net=host \
+  -v /:/mnt/root \
+  -v /run:/run \
+  -v /etc/kubernetes:/etc/kubernetes \
+  -v /var/lib/ignition:/usr/share/oem \
+  gcr.io/mikedanese-k8s/ignite:v3
+
+systemctl enable kubelet
+systemctl start kubelet

--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -1,0 +1,26 @@
+# This is not meant to run on its own, but extends phase1/gce/configure-vm.sh
+
+TOKEN=$(get_metadata "k8s-kubeadm-token")
+
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+
+cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+
+apt-get update
+apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+
+case "${ROLE}" in
+  "master")
+    kubeadm init --token "${TOKEN}"
+    ;;
+  "node")
+    MASTER=$(get_metadata "k8s-master-ip")
+    kubeadm join --token "${TOKEN}" "${MASTER}"
+    ;;
+  *)
+    echo invalid phase2 provider.
+    exit 1
+    ;;
+esac

--- a/phase1/gce/configure-vm.sh
+++ b/phase1/gce/configure-vm.sh
@@ -13,31 +13,6 @@ get_metadata() {
 
 ROLE=$(get_metadata "k8s-role")
 
-mkdir -p /etc/kubernetes/
-get_metadata "k8s-config" > /etc/kubernetes/k8s_config.json
-
-mkdir -p /srv/kubernetes
-case "${ROLE}" in
-  "master")
-    get_metadata "k8s-ca-public-key" \
-      > /srv/kubernetes/ca.pem
-    get_metadata "k8s-apisever-public-key" \
-      > /srv/kubernetes/apiserver.pem
-    get_metadata "k8s-apisever-private-key" \
-      > /srv/kubernetes/apiserver-key.pem
-    get_metadata "k8s-master-kubeconfig" \
-      > /srv/kubernetes/kubeconfig.json
-    ;;
-  "node")
-    get_metadata "k8s-node-kubeconfig" \
-      > /srv/kubernetes/kubeconfig.json
-    ;;
-  *)
-    echo "'${ROLE}' is not a valid role"
-    exit 1
-    ;;
-esac
-
 cat <<EOF > /etc/apt/sources.list.d/k8s.list
 deb [arch=amd64] https://apt.dockerproject.org/repo ubuntu-xenial main
 EOF
@@ -53,14 +28,3 @@ apt-get update
 apt-get install -y docker-engine=1.12.0-0~xenial
 systemctl enable docker || true
 systemctl start docker || true
-
-docker run \
-  --net=host \
-  -v /:/mnt/root \
-  -v /run:/run \
-  -v /etc/kubernetes:/etc/kubernetes \
-  -v /var/lib/ignition:/usr/share/oem \
-  gcr.io/mikedanese-k8s/ignite:v3
-
-systemctl enable kubelet
-systemctl start kubelet

--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -7,18 +7,24 @@ set -x
 
 cd "${BASH_SOURCE%/*}"
 
+generate_token() {
+  perl -e 'printf "%06X.%08X%08X\n", rand(0xffffff), rand(0xffffffff), rand(0xffffffff);'
+}
+
 gen() {
+  TOKEN=$(generate_token)
   mkdir -p .tmp/
   jsonnet -J ../../ --multi .tmp/ all.jsonnet
+  echo "kubeadm_token = \"$TOKEN\"" > .tmp/terraform.tfvars
 }
 
 deploy() {
   gen
-  terraform apply .tmp
+  terraform apply -var-file .tmp/terraform.tfvars .tmp
 }
 
 destroy() {
-  terraform destroy .tmp
+  terraform destroy -var-file .tmp/terraform.tfvars .tmp
 }
 
 case "${1:-}" in

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -17,4 +17,12 @@ config phase2.kubernetes_version
 	help
 	  The version of Kubernetes to deploy.
 
+config phase2.provider
+	string "bootstrap provider"
+	default "ignition"
+	help
+	  The bootstrap provider to use.
+
+	  Valid options are (ignition, kubeadm).
+
 endmenu


### PR DESCRIPTION
Currently, this only supports using the most recent .deb packages.

- Exposes port 9898 internally for discovery service
- Nodes use master's internal IP
- Move a lot of configure-vm.sh logic into phase2 provider dirs (which get concatenated by jsonnet)

CC @mikedanese 