### PR TITLE
Fixes #271: Output GCE's kubeconfig.json to .tmp

### DIFF
--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -163,7 +163,7 @@ function(cfg)
         kubeconfig: {
           provisioner: [{
             "local-exec": {
-              command: "echo '%s' > kubeconfig.json" % kubeconfig(p1.cluster_name + "-admin", p1.cluster_name, p1.cluster_name),
+              command: "echo '%s' > .tmp/kubeconfig.json" % kubeconfig(p1.cluster_name + "-admin", p1.cluster_name, p1.cluster_name),
             },
           }],
         },


### PR DESCRIPTION
This matches what azure does, and the expectations of the Makefile.

After this change, doing `make deploy` is fixed for GCE, since `util/validate` is able to find the correct configuration to connect and count the nodes.

See https://github.com/kubernetes/kubernetes-anywhere/issues/271

CC @mikedanese 