### PR TITLE
Support FORCE_DESTROY option in gce.

### DIFF
--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -24,7 +24,11 @@ deploy() {
 }
 
 destroy() {
-  terraform destroy -var-file .tmp/terraform.tfvars .tmp
+  FLAGS=""
+  if [[ "${FORCE_DESTROY:-}" == "y" ]]; then
+    FLAGS="-force"
+  fi
+  terraform destroy -var-file .tmp/terraform.tfvars $FLAGS .tmp
 }
 
 case "${1:-}" in


### PR DESCRIPTION
This is already implemented in the azure phase1, and will allow users to automate destruction without interactive prompts:

    $ make FORCE_DESTROY=y destroy

This change is built on top of another pull request (https://github.com/kubernetes/kubernetes-anywhere/pull/270) so please only look at the newest commit.

CC @mikedanese 