### PR TITLE
New make target: kubeconfig-path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,16 @@ echo-config: .config.json
 deploy-cluster destroy-cluster: .config.json
 	$(MAKE) do WHAT=$@
 
+# For maximum usefulness, use this target with "make -s" to silence any trace output, e.g.:
+#   $ export KUBECONFIG=$(make -s kubeconfig-path)
+kubeconfig-path: .config.json
+	@$(eval KUBECONFIG_PATH := $(shell pwd)/phase1/$(shell jq -r '.phase1.cloud_provider' .config.json)/.tmp/kubeconfig.json)
+	@if [ ! -e "$(KUBECONFIG_PATH)" ]; then \
+		echo "Cannot find kubeconfig file. Have you started a cluster with \"make deploy\" yet?" > /dev/stderr; \
+		exit 1; \
+	fi
+	@echo $(KUBECONFIG_PATH)
+
 validate: .config.json
 	KUBECONFIG="$$(pwd)/phase1/$$(jq -r '.phase1.cloud_provider' .config.json)/.tmp/kubeconfig.json" ./util/validate
 


### PR DESCRIPTION
As a consumer of kubernetes-anywhere, I wanted a supported way to discover the `kubeconfig.json` file path without relying on the internal details of where it's stored per phase1 provider.

The target name feels a little awkward, so I'm open to suggestions of a better one.

CC @mikedanese 