### PR TITLE
Force API port 443 to match other implementations.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -13,7 +13,7 @@ apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 
 case "${ROLE}" in
   "master")
-    kubeadm init --token "${TOKEN}"
+    kubeadm init --token "${TOKEN}" --api-port 443
     ;;
   "node")
     MASTER=$(get_metadata "k8s-master-ip")


### PR DESCRIPTION
`Kubeadm` now defaults to 6443 for the secure API listener, so override it to match the conventions of the rest of `kubernetes-anywhere`.

CC @mikedanese 