### PR TITLE
Specify master's external IP via --api-advertise-addresses.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -13,7 +13,7 @@ apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 
 case "${ROLE}" in
   "master")
-    kubeadm init --token "${TOKEN}" --api-port 443 --skip-preflight-checks
+    kubeadm init --token "${TOKEN}" --api-port 443 --skip-preflight-checks --api-advertise-addresses "$(get_metadata "k8s-advertise-addresses")"
     ;;
   "node")
     MASTER=$(get_metadata "k8s-master-ip")

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -148,6 +148,7 @@ function(cfg)
             "k8s-apisever-private-key": "${tls_private_key.%s-master.private_key_pem}" % p1.cluster_name,
             "k8s-master-kubeconfig": kubeconfig(p1.cluster_name + "-master", "local", "service-account-context"),
             "k8s-kubeadm-token": "${var.kubeadm_token}",
+            "k8s-advertise-addresses": "${google_compute_address.%(master_ip)s.address}" % names,
           },
           disk: [{
             image: gce.os_image,


### PR DESCRIPTION
This allows `kubeadm init` to include the master's external IP as part of the TLS certificate. Otherwise, remote clients reject the certificate since it doesn't match the IP they're connecting to.

CC @mikedanese 