### PR TITLE
Skip kubeadm preflight checks.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -13,11 +13,11 @@ apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 
 case "${ROLE}" in
   "master")
-    kubeadm init --token "${TOKEN}" --api-port 443
+    kubeadm init --token "${TOKEN}" --api-port 443 --skip-preflight-checks
     ;;
   "node")
     MASTER=$(get_metadata "k8s-master-ip")
-    kubeadm join --token "${TOKEN}" "${MASTER}"
+    kubeadm join --token "${TOKEN}" "${MASTER}" --skip-preflight-checks
     ;;
   *)
     echo invalid phase2 provider.


### PR DESCRIPTION
A race condition in one of `kubeadm`'s preflight checks has been causing occasional failures of masters/nodes to come up correctly.

Since we provide a completely automated setup, any failed preflight checks don't offer much value since the user isn't interacting with `kubeadm` to see its error messages and address the issues, so we should
disable them anyway.

CC @mikedanese 