### PR TITLE
Fix: Kubelet restarts for vSphere CloudProvider

### DIFF
--- a/phase1/vsphere/README.md
+++ b/phase1/vsphere/README.md
@@ -55,7 +55,7 @@ and fill complete the config wizard to deploy a kubernetes-anywhere cluster.
 * To properly boot a cluster in vSphere, you MUST set these values in the wizard:
 
   ```
-  * phase2.installer_container = "docker.io/ashivani/k8s-ignition:v3"
+  * phase2.installer_container = "docker.io/ashivani/k8s-ignition:v4"
   ```
 
 * To change configuration, run: ``` make config .config```
@@ -89,6 +89,7 @@ $ make destroy
 to tear down your cluster.
 
 ## Issues
+  
   1. ```make destroy``` is flaky.
 
      Terraform fails to destroy VM's and remove the state for existing cluster. 
@@ -97,11 +98,6 @@ to tear down your cluster.
         1. Stop all VM's that are setup by kubernetes-anywhere.
         2. Right-Click on VM and select ```Delete from Disk```.
         3. Run ```make clean```.
-
-  2. kubelet doesn't restart when node restarts.
-     
-      * Workaround:
-        Run ```systemctl start kubelet``` on that node.
 
 ## Troubleshooting
 

--- a/phase2/ignition/vanilla/kubelet.service
+++ b/phase2/ignition/vanilla/kubelet.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/kubernetes/kubernetes
-After=docker.service
-Requires=docker.service
+Requires=docker.service network-online.target
+After=docker.service network-online.target
 
 [Service]
 ExecStartPre=/bin/mkdir -p /var/lib/kubelet
@@ -23,6 +23,8 @@ ExecStart=/usr/bin/docker run \
         %(docker_registry)s/hyperkube-amd64:%(kubernetes_version)s \
         /hyperkube kubelet %(kubelet_args)s
 Restart=always
+StartLimitInterval=0
+RestartSec=10
 KillMode=process
 
 [Install]

--- a/phase2/ignition/vanilla/kubelet.service
+++ b/phase2/ignition/vanilla/kubelet.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Kubernetes Kubelet Server
 Documentation=https://github.com/kubernetes/kubernetes
+After=docker.service
+Requires=docker.service
 
 [Service]
 ExecStartPre=/bin/mkdir -p /var/lib/kubelet


### PR DESCRIPTION
In vSphere CloudProvider, when node restarts, kubelet doesn't start. This PR fixes the same.