### PR TITLE
kube-anywhere doesn't work with multiple resource pools in vSphere

### DIFF
--- a/phase1/vsphere/Kconfig
+++ b/phase1/vsphere/Kconfig
@@ -39,6 +39,12 @@ config phase1.vSphere.datastore
 	help
 		The datastore where VMs will be created.
 
+config phase1.vSphere.resourcepool
+        string "Resourcepool"
+        default "/datacenter/host/<host-ip> (or) <vc-cluster-name>/Resources"
+        help
+                The resourcepool where VMs will be created.
+
 config phase1.vSphere.vcpu
 	string "Number of vcpu"
 	default "1"

--- a/phase1/vsphere/vSphere.jsonnet
+++ b/phase1/vsphere/vSphere.jsonnet
@@ -100,7 +100,8 @@ function(config)
             memory: cfg.vSphere.memory,
             enable_disk_uuid: true,
             datacenter: cfg.vSphere.datacenter,
-            skip_customization: true,
+            resource_pool: cfg.vSphere.resourcepool,
+	    skip_customization: true,
             folder: "${vsphere_folder.cluster_folder.path}",
             network_interface: {
               label: "VM Network",


### PR DESCRIPTION
Currently kube-anywhere doesn't work with multiple resource pools. Consider the below scenario:

I have a VC deployed with multiple clusters and hence multiple resource pools. I deployed the "KubernetesAnywhereTemplatePhotonOS" in one of the ESX boxes present in one of the clusters.

when I did make deploy, kube-anywhere fails to deploy and reports the following errors.

Error applying plan:

2 error(s) occurred:

* vsphere_virtual_machine.kubevm2: default resource pool resolves to multiple instances, please specify
* vsphere_virtual_machine.kubevm1: default resource pool resolves to multiple instances, please specify

Right now kube-anywhere doesn't take into consideration the resource pools as a config parameter that must provided to the user to be entered. This is in contrast with kube-up which needs a resource pool to be configured in order for kubernetes cluster to be created.

kube-anywhere right now works with single resource pool.

This fix will make sure kube-anywhere works with multiple resource pools. The resource pool is provided as a config entry to the user.

@abrarshivani @kerneltime @pdhamdhere