### PR TITLE
Add support for gs:// links for kubeadm .debs.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -1,15 +1,28 @@
 # This is not meant to run on its own, but extends phase1/gce/configure-vm.sh
 
 TOKEN=$(get_metadata "k8s-kubeadm-token")
+KUBEADM_VERSION=$(get_metadata "k8s-kubeadm-version")
 
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
-cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
-deb http://apt.kubernetes.io/ kubernetes-xenial main
+if [[ "${KUBEADM_VERSION}" == stable ]]; then
+  cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+  deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
-apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+  apt-get update
+  apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+elif [[ "${KUBEADM_VERSION}" == "gs://"* ]]; then
+  TMPDIR=/tmp/k8s-debs
+  mkdir $TMPDIR
+  gsutil rsync "${KUBEADM_VERSION}" $TMPDIR
+  dpkg -i $TMPDIR/{kubelet,kubeadm,kubectl,kubernetes-cni}.deb || echo Ignoring expected dpkg failure
+  apt-get install -f -y
+  rm -rf $TMPDIR
+else
+  echo "Don't know how to handle version: $KUBEADM_VERSION"
+  exit 1
+fi
 
 case "${ROLE}" in
   "master")

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -147,9 +147,11 @@ function(cfg)
             "k8s-apisever-public-key": "${tls_locally_signed_cert.%s-master.cert_pem}" % p1.cluster_name,
             "k8s-apisever-private-key": "${tls_private_key.%s-master.private_key_pem}" % p1.cluster_name,
             "k8s-master-kubeconfig": kubeconfig(p1.cluster_name + "-master", "local", "service-account-context"),
-            "k8s-kubeadm-token": "${var.kubeadm_token}",
             "k8s-advertise-addresses": "${google_compute_address.%(master_ip)s.address}" % names,
-          },
+          } + if p2.provider == "kubeadm" then {
+            "k8s-kubeadm-token": "${var.kubeadm_token}",
+            "k8s-kubeadm-version": "%(version)s" % p2.kubeadm
+          } else { },
           disk: [{
             image: gce.os_image,
           }],
@@ -169,8 +171,10 @@ function(cfg)
             "k8s-config": config_metadata_template % [names.master_ip, "node"],
             "k8s-node-kubeconfig": kubeconfig(p1.cluster_name + "-node", "local", "service-account-context"),
             "k8s-master-ip": "${google_compute_instance.%(master_instance)s.network_interface.0.address}" % names,
+          } + if p2.provider == "kubeadm" then {
             "k8s-kubeadm-token": "${var.kubeadm_token}",
-          },
+            "k8s-kubeadm-version": "%(version)s" % p2.kubeadm
+          } else { },
           disk: [{
             source_image: gce.os_image,
             auto_delete: true,

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -25,4 +25,16 @@ config phase2.provider
 
 	  Valid options are (ignition, kubeadm).
 
+if phase2.provider = kubeadm
+
+config phase2.kubeadm.version
+	string "kubeadm version"
+	default "stable"
+	help
+	  The version of kubeadm to use.
+
+	  Valid options are "stable" or a Google Cloud Storage link to a build.
+
+endif
+
 endmenu


### PR DESCRIPTION
Instead of only supporting the latest stable release, allow specifying a Cloud Storage link for pulling arbitary builds. This should allow developers to bring up kubeadm clusters using their local development build, as well as help e2e test kubeadm on pull requests or master commits.

CC @mikedanese 