### PR TITLE
Updated documentation to recommend kubernetes 1.4.8 for vSphere Cloud Provider

### DIFF
--- a/phase1/vsphere/README.md
+++ b/phase1/vsphere/README.md
@@ -15,11 +15,11 @@
 
 **Note**:
 
-The recommended version is v1.4.7
+The recommended version is v1.4.8
 
-The deployment is tested with kubernetes v1.4.0, v1.4.4 and v1.4.7
+The deployment is tested with kubernetes v1.4.0, v1.4.4, v1.4.7 and v1.4.8
 
-vSphere Cloud Provider is tested on v1.4.7
+vSphere Cloud Provider is tested on v1.4.7 and v1.4.8
 
 ### Upload VM image to be used to vSphere:
 
@@ -152,7 +152,7 @@ docker registry (phase2.docker_registry) [gcr.io/google-containers] (NEW)
 
 * Set the release of Kubernetes to be used. The release should be the exact string used to tag a release.
 ```
-kubernetes version (phase2.kubernetes_version) [v1.4.7] (NEW) v1.4.7
+kubernetes version (phase2.kubernetes_version) [v1.4.8] (NEW) v1.4.8
 ```
 
 * Set bootstrap provider to ignition
@@ -210,7 +210,7 @@ To access the dashboard after successful instllation of kubernetes cluster. Ther
 
 * Run ```kubectl proxy``` outside the container spawned by ```make docker-dev```
 ```
-curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.4.7/bin/linux/amd64/kubectl
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.4.8/bin/linux/amd64/kubectl
 chmod u+x kubectl
 export KUBECONFIG=phase1/vsphere/.tmp/kubeconfig.json
 ./kubectl proxy

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -13,7 +13,7 @@ config phase2.docker_registry
 
 config phase2.kubernetes_version
 	string "kubernetes version"
-	default "v1.4.7"
+	default "v1.4.8"
 	help
 	  The version of Kubernetes to deploy.
 


### PR DESCRIPTION
Changes for the issue - https://github.com/vmware/kubernetes/issues/54

@kerneltime @BaluDontu Updated phase1/vsphere/README.md and phase2/Kconfig to recommend kubernetes 1.4.8 for vSphere Cloud Provider