### PR TITLE
Use lowercase hex token for kubeadm commands.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -31,7 +31,6 @@ case "${ROLE}" in
     ;;
   "node")
     MASTER=$(get_metadata "k8s-master-ip")
-    echo kubeadm join --discovery "token://${TOKEN}@${MASTER}:9898" --skip-preflight-checks
     kubeadm join --discovery "token://${TOKEN}@${MASTER}:9898" --skip-preflight-checks
     ;;
   *)

--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -8,7 +8,7 @@ set -x
 cd "${BASH_SOURCE%/*}"
 
 generate_token() {
-  perl -e 'printf "%06X:%08X%08X\n", rand(0xffffff), rand(0xffffffff), rand(0xffffffff);'
+  perl -e 'printf "%06x:%08x%08x\n", rand(0xffffff), rand(0xffffffff), rand(0xffffffff);'
 }
 
 gen() {


### PR DESCRIPTION
The kubeadm command was updated to do input validation on
the token used for initializing and joining clusters. This update
generates lowercase tokens to match the kubeadm input rules.