### PR TITLE
Add default storage backend as etcd3

### DIFF
--- a/phase2/ignition/vanilla/manifest/etcd.jsonnet
+++ b/phase2/ignition/vanilla/manifest/etcd.jsonnet
@@ -11,7 +11,7 @@ function(cfg)
       containers: [
         {
           name: "etcd-container",
-          image: "gcr.io/google_containers/etcd:2.2.1",
+          image: "gcr.io/google_containers/etcd:3.0.4",
           resources: {
             requests: {
               cpu: "200m",
@@ -23,8 +23,8 @@ function(cfg)
             |||
               /usr/local/bin/etcd \
                 --listen-peer-urls http://127.0.0.1:2380 \
-                --addr 127.0.0.1:2379 \
-                --bind-addr 127.0.0.1:2379 \
+                -advertise-client-urls http://127.0.0.1:2379 \
+                -listen-client-urls http://127.0.0.1:2379 \
                 --data-dir /var/etcd/data
             |||,
           ],

--- a/phase2/ignition/vanilla/manifest/kube-apiserver.jsonnet
+++ b/phase2/ignition/vanilla/manifest/kube-apiserver.jsonnet
@@ -35,6 +35,7 @@ function(cfg)
               "--tls-cert-file=/srv/kubernetes/apiserver.pem",
               "--tls-private-key-file=/srv/kubernetes/apiserver-key.pem",
               "--secure-port=443",
+              "--storage-backend=etcd3", 
               "--allow-privileged",
               "--v=4",
             ],

--- a/phase2/ignition/vanilla/node.jsonnet
+++ b/phase2/ignition/vanilla/node.jsonnet
@@ -19,7 +19,7 @@ function(cfg)
               "--enable-server",
               "--enable-debugging-handlers",
               "--kubeconfig=/srv/kubernetes/kubeconfig.json",
-              "--config=/etc/kubernetes/manifests",
+              "--pod-manifest-path=/etc/kubernetes/manifests",
               "--cluster-dns=10.0.0.10",
               "--cluster-domain=cluster.local",
               "--v=2",


### PR DESCRIPTION
This PR adds parameter default storage backend to apiserver as etcd2. While launching k8s-cluster with kubernetes master branch (commit d82e51e) using kubernetes-anywhere. I found that kubernetes api-server fails with an error

```
E0111 03:00:53.829193   29597 status.go:62] apiserver received an error that is not an metav1.Status: rpc error: code = 13 desc = transport is closing
…
logging error output: "k8s\x00\n\f\n\x02v1\x12\x06Status\x12F\n\x04\n\x00\x12\x00\x12\aFailure\x1a0rpc error: code = 13 desc = transport is closing\"\x000\xf4\x03\x1a\x00\"\x00"
```
Currently, etcd3 is made as default storage backend for api-server and kubernetes-anywhere uses etcd2. Hence, this error occurs. This can be resolved by adding parameter ```storage-backend=etcd2``` to apiserver manifest.

Refer this: https://github.com/kubernetes/kubernetes/issues/39710