### PR TITLE
Move kubectl download to phase2 for vSphere CloudProvider

### DIFF
--- a/phase1/vsphere/README.md
+++ b/phase1/vsphere/README.md
@@ -150,7 +150,7 @@ cloud provider: gce, azure or vsphere (phase1.cloud_provider) [gce] (NEW) vspher
 *
 * Phase 2: Node Bootstrapping
 *
-installer container (phase2.installer_container) [docker.io/colemickens/k8s-ignition:latest] (NEW) docker.io/ashivani/k8s-ignition:v4
+installer container (phase2.installer_container) [docker.io/cnastorage/k8s-ignition:v1] (NEW) docker.io/cnastorage/k8s-ignition:v1
 ```
 
 * Registry to be used by Kubernetes
@@ -184,11 +184,7 @@ Run the addon manager? (phase3.run_addons) [Y/n/?] (NEW)
 
 * Set the resource pool to be same as the one selected during import of OVA above.
 
-* To properly boot a cluster in vSphere, you MUST set these values in the wizard:
-
-  ```
-  * phase2.installer_container = "docker.io/ashivani/k8s-ignition:v4"
-  ```
+* You can build your own ```phase2.installer_container``` using Dockerfile [here](https://github.com/kubernetes/kubernetes-anywhere/blob/master/phase2/ignition/Dockerfile).
 
 * To change configuration, run: ``` make config .config```. Run ```make clean``` before ```make deploy```
 

--- a/phase1/vsphere/configure-vm.sh
+++ b/phase1/vsphere/configure-vm.sh
@@ -49,8 +49,3 @@ systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet
 
-if [ "${role}" == "master" ]; then
-    # Download kubectl
-    curl -o /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${kubernetes_version}/bin/linux/amd64/kubectl
-    chmod 777 /bin/kubectl
-fi

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -3,7 +3,7 @@ menu "Phase 2: Node Bootstrapping"
 
 config phase2.installer_container
 	string "installer container"
-	default "docker.io/colemickens/k8s-ignition:latest"
+	default "docker.io/cnastorage/k8s-ignition:v1"
 
 config phase2.docker_registry
 	string "docker registry"

--- a/phase2/ignition/Dockerfile
+++ b/phase2/ignition/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 RUN apk --update add openssl ca-certificates
 
-RUN wget https://storage.googleapis.com/public-mikedanese-k8s/k8s/ignition \
+RUN wget https://storage.googleapis.com/kubernetes-anywhere-for-vsphere-cna-storage/ignition \
   -O /bin/ignition \
   && chmod +x /bin/ignition
 

--- a/phase2/ignition/vanilla/master.jsonnet
+++ b/phase2/ignition/vanilla/master.jsonnet
@@ -1,6 +1,8 @@
 function(cfg)
   (import "node.jsonnet")(cfg) {
-    local util = import "util.jsonnet",
+    local util = import "util.jsonnet",   
+    local phase2 = cfg.phase2,
+    local kubectl = "https://storage.googleapis.com/kubernetes-release/release/" + phase2.kubernetes_version + "/bin/linux/amd64/kubectl",
     storage: {
       filesystems: [{
         name: "root",
@@ -35,8 +37,8 @@ function(cfg)
           filesystem: "root",
           path: "/usr/local/bin/kubectl",
           contents: {
-            source: "https://storage.googleapis.com/kubernetes-release/release/v1.3.4/bin/linux/amd64/kubectl",
-          },
+            source: kubectl,
+	  },
           mode: 511,
         },
       ],


### PR DESCRIPTION
For vSphere cloud provider kubectl was downloaded in phase1 since downloading in phase2 using ignition gave an [error](https://github.com/kubernetes/kubernetes-anywhere/issues/286). Now, that is [fixed](https://github.com/kubernetes/kubernetes-anywhere/pull/305) this PR removes the downloading of kubectl from phase1 of vSphere Cloud Provider. Also, kubectl downloaded in phase2 was of v1.3.4 even though kubernetes cluster launched was of different version. This PR fixes that.

@mikedanese Can you please build the static binary and update at https://storage.googleapis.com/public-mikedanese-k8s/k8s/ignition? Also, I tested with master branch of ignition it fails therefore can you build binary for commit 6ff90ec7f985d783246fc429ea.