### PR TITLE
Writing vsphere conf before launching ignition container

### DIFF
--- a/phase1/vsphere/vSphere.jsonnet
+++ b/phase1/vsphere/vSphere.jsonnet
@@ -127,8 +127,8 @@ function(config)
                 "remote-exec": {
                   inline: [
                     "mkdir -p /etc/kubernetes/; echo '%s' > /etc/kubernetes/k8s_config.json " % (config_metadata_template % "master"),                    
-                    "echo '%s' > /etc/configure-vm.sh; bash /etc/configure-vm.sh" % "${data.template_file.configure_master.rendered}",
                     "echo '%s' >  /etc/kubernetes/vsphere.conf" % "${data.template_file.cloudprovider.rendered}",            
+                    "echo '%s' > /etc/configure-vm.sh; bash /etc/configure-vm.sh" % "${data.template_file.configure_master.rendered}",
                   ]
                 }
            }, {


### PR DESCRIPTION
Kubernetes-anywhere scripts were writing vsphere.conf after launching of ignition container which created race condition between vSphere.conf and apiserver. This PR fixes that.

Fixes this error,
```
Feb 14 15:05:16 photon-zv1KbtvMG docker[626]: F0214 15:05:16.854753     709 plugins.go:80] Couldn't open cloud provider configuration /etc/kubernetes/vsphere.conf: &os.PathError{
Op:"open", Path:"/etc/kubernetes/vsphere.conf", Err:0x2}
```