### PR TITLE
Download right version of kubectl binary

### DIFF
--- a/phase1/vsphere/do
+++ b/phase1/vsphere/do
@@ -16,6 +16,19 @@ gen() {
 deploy() {
   gen
   terraform apply -state=./.tmp/terraform.tfstate .tmp
+  rm /usr/local/bin/kubectl
+  COMMAND="grep '.phase2.kubernetes_version' ../../.config | cut -d '=' -f2 | tr -d '\"'"
+  KUBERNETES_VERSION=$(eval $COMMAND)
+  # If the kubectl binary doesn't exist download it.
+  if [ ! -f /usr/local/bin/kubectl_$KUBERNETES_VERSION ]; then
+    echo "Kubectl binary with version - $KUBERNETES_VERSION doesn't exist. So downloading it."
+    wget https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl_$KUBERNETES_VERSION
+    chmod +x /usr/local/bin/kubectl_$KUBERNETES_VERSION
+  else
+    echo "Kubectl binary with version - $KUBERNETES_VERSION already exists."
+  fi
+  # Create a symbolic link to the kubectl version binary.
+  ln -s /usr/local/bin/kubectl_$KUBERNETES_VERSION /usr/local/bin/kubectl
 }
 
 destroy() {


### PR DESCRIPTION
Currently Kube-anywhere installs 1.4.0 kubectl binary inside the container spawned by using "make docker-dev" for any kubernetes cluster deployments either it be 1.4.7, 1.4.8, 1.5.2 or 1.5.3.

So there needs to be a better way to download the specific version of kubectl based on the Kubernetes cluster the user wants to deploy. For example, if the user deployed v1.5.3 kubernetes cluster, the container needs to have a kubectl v1.5.3 binary working in place. If the user deployed v1.4.8 kubernetes cluster, the container needs to have a kubectl v1.4.8 binary working in place..

Also, there needs to be a way where the kubectl binary for a specific version can be used if it is already downloaded rather than downloading it again every time.

The fix for this PR will handle the above mentioned 2 cases.

@mikedanese @abrarshivani @pdhamdhere @kerneltime 