### PR TITLE
vSphere: The proxy to the Kubernetes API server is http

### DIFF
--- a/phase1/vsphere/README.md
+++ b/phase1/vsphere/README.md
@@ -230,8 +230,9 @@ chmod u+x kubectl
 export KUBECONFIG=phase1/vsphere/.tmp/kubeconfig.json
 ./kubectl proxy
 Starting to serve on 127.0.0.1:8001
-# Open the https://127.0.0.1:8001/ui in a browser
 ``` 
+
+Open the http://127.0.0.1:8001/ui in a browser
 
 * Access the dashboard from the node it is running on via NodePort mapping
 ```


### PR DESCRIPTION
On vSphere instructions, the dashboard is running in http, not https.