### PR TITLE
skip downloading kubelet if URL is not accessible

### DIFF
--- a/phase1/vsphere/do
+++ b/phase1/vsphere/do
@@ -16,19 +16,26 @@ gen() {
 deploy() {
   gen
   terraform apply -state=./.tmp/terraform.tfstate .tmp
-  rm /usr/local/bin/kubectl
   COMMAND="grep '.phase2.kubernetes_version' ../../.config | cut -d '=' -f2 | tr -d '\"'"
   KUBERNETES_VERSION=$(eval $COMMAND)
   # If the kubectl binary doesn't exist download it.
   if [ ! -f /usr/local/bin/kubectl_$KUBERNETES_VERSION ]; then
     echo "Kubectl binary with version - $KUBERNETES_VERSION doesn't exist. So downloading it."
-    wget https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl_$KUBERNETES_VERSION
-    chmod +x /usr/local/bin/kubectl_$KUBERNETES_VERSION
+    if wget --spider https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl 2>/dev/null; then
+      rm -rf /usr/local/bin/kubectl
+      wget https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl_$KUBERNETES_VERSION
+      if [ -f /usr/local/bin/kubectl_$KUBERNETES_VERSION ]; then
+        chmod +x /usr/local/bin/kubectl_$KUBERNETES_VERSION
+        # Create a symbolic link to the kubectl version binary.
+        ln -s /usr/local/bin/kubectl_$KUBERNETES_VERSION /usr/local/bin/kubectl
+      fi
+    else
+      echo "Kubectl binary is not available at https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl"
+    fi
   else
     echo "Kubectl binary with version - $KUBERNETES_VERSION already exists."
+    ln -sf /usr/local/bin/kubectl_$KUBERNETES_VERSION /usr/local/bin/kubectl
   fi
-  # Create a symbolic link to the kubectl version binary.
-  ln -s /usr/local/bin/kubectl_$KUBERNETES_VERSION /usr/local/bin/kubectl
 }
 
 destroy() {


### PR DESCRIPTION
while deploying kubernetes cluster user can specify hyperkube version from docker registry as below.

```
docker registry (phase2.docker_registry) [gcr.io/google-containers] (NEW) gcr.io/google-containers
kubernetes version (phase2.kubernetes_version) [v1.5.3] (NEW) v1.5.3
```

but when user is using custom hyperkube image from private repository - `https://hub.docker.com/r/divyen/hyperkube-amd64/tags/` for example as below

```
docker registry (phase2.docker_registry) [gcr.io/google-containers] (NEW) docker.io/divyen
kubernetes version (phase2.kubernetes_version) [v1.5.3] (NEW) nightly-1.5
```
kubernete-anywhere will try to download kubelet from `https://storage.googleapis.com/kubernetes-release/release/nightly-1.5/bin/linux/amd64/kubectl` which is not the right URL.

to avoid failing deployment, we can check if URL is accessible, and if accessible then only delete existing kubelet binary and replace it with available kubelet binary from URL.

in this case, users can manually download desired version of kubelet in the kubernete anywhere dev container.


cc: @abrarshivani @BaluDontu @tusharnt @pdhamdhere @luomiao @kerneltime 
