### PR TITLE
Accommodate upstream kubeadm CLI changes.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -27,11 +27,11 @@ fi
 
 case "${ROLE}" in
   "master")
-    kubeadm init --discovery "token://${TOKEN}@" --api-port 443 --skip-preflight-checks --api-advertise-addresses "$(get_metadata "k8s-advertise-addresses")" --use-kubernetes-version $KUBERNETES_VERSION
+    kubeadm init --token "${TOKEN}" --apiserver-bind-port 443 --skip-preflight-checks --apiserver-advertise-address "$(get_metadata "k8s-advertise-addresses")" --kubernetes-version $KUBERNETES_VERSION
     ;;
   "node")
     MASTER=$(get_metadata "k8s-master-ip")
-    kubeadm join --discovery "token://${TOKEN}@${MASTER}:9898" --skip-preflight-checks
+    kubeadm join --token "${TOKEN}" "${MASTER}:443" --skip-preflight-checks
     ;;
   *)
     echo invalid phase2 provider.

--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -8,7 +8,7 @@ set -x
 cd "${BASH_SOURCE%/*}"
 
 generate_token() {
-  perl -e 'printf "%06x:%08x%08x\n", rand(0xffffff), rand(0xffffffff), rand(0xffffffff);'
+  perl -e 'printf "%06x.%08x%08x\n", rand(0xffffff), rand(0xffffffff), rand(0xffffffff);'
 }
 
 gen() {


### PR DESCRIPTION
- The `--discovery` flag has reverted back to `--token`
- Token strings are back to `<6>.<16>` instead of `<6>:<16>`
- `--api-advertise-addresses` is now `--apiserver-advertise-address`
- `--api-port` is now `--apiserver-bind-port`
- `--use-kubernetes-version` is now `--kubernetes-version`

CC @luxas @mikedanese 