### PR TITLE
Remove unnecessary quoting of SHELLFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 SHELL=/bin/bash
-.SHELLFLAGS="-O" "extglob" "-o" "errexit" "-o" "pipefail" "-o" "nounset" "-c"
+.SHELLFLAGS=-O extglob -o errexit -o pipefail -o nounset -c
 
 .PHONY: config echo-config
 


### PR DESCRIPTION
For some reason, this was breaking the multiline `if` used in the kubeconfig-path target under different versions of make/bash. Removing these quotes fixed the kubeconfig-path make target in the docker-dev shell.