### PR TITLE
Add port 15441 forwarding to apiserver

### DIFF
--- a/phase2/ignition/vanilla/manifest/kube-apiserver.jsonnet
+++ b/phase2/ignition/vanilla/manifest/kube-apiserver.jsonnet
@@ -64,6 +64,11 @@ function(cfg)
               containerPort: 8080,
               hostPort: 8080,
             },
+            {
+              name: "rkt",
+              containerPort: 15441,
+              hostPort: 15441,
+            },
           ],
           volumeMounts: [
             {


### PR DESCRIPTION
My vSphere deployment failed with the error `Validation: Expected 5 healthy nodes; found 0.`.

From master node's journalctl I found that it tried to connect to localhost:15441 but failed:

    Mar 10 11:16:21 master docker[606]: W0310 11:16:21.519288     703 manager.go:151] unable to connect to Rkt api service: rkt: cannot tcp Dial rkt api service: dial tcp [::1]:15441: getsockopt: connection refused

With this PR, I managed to get the cluster running.

NB: I'm not aware where this problem came from in the first place - or whether this would be the correct way to fix the problem.

