### PR TITLE
Fix sed command.

### DIFF
--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -51,7 +51,7 @@ fetch_kubeconfig() {
     # a marker to indicate the start of the file, and delete all lines up to and
     # including it.
     if gcloud compute ssh --project "$PROJECT" --zone "$ZONE" "$MASTER" --command "echo STARTFILE; sudo cat /etc/kubernetes/admin.conf" > .tmp/kubeconfig.raw; then
-      sed '1,/^STARTFILE$/d' .tmp/kubeconfig.raw > .tmp/kubeconfig.json
+      sed '0,/^STARTFILE$/d' .tmp/kubeconfig.raw > .tmp/kubeconfig.json
       echo Successfully fetched kubeconfig.
       return
     else


### PR DESCRIPTION
This was a silly mistake in 02dddef. If the very first line was `STARTFILE`, then the entire file was getting truncated. Using `0` instead of `1` for the range matching allows the match to occur on the first line, giving the intended behavior if nothing else comes before `STARTFILE`.