### PR TITLE
Add support for weave-net addon.

### DIFF
--- a/phase3/Kconfig
+++ b/phase3/Kconfig
@@ -32,6 +32,12 @@ config phase3.kube_dns
 	default y
 	help
 	  Should we deploy kube-dns?
+
+config phase3.weave_net
+	bool "Run weave-net?"
+	default n
+	help
+	  Should we deploy weave-net? You likely only want this if using kubeadm for phase2.
 endif
 
 endmenu

--- a/phase3/all.jsonnet
+++ b/phase3/all.jsonnet
@@ -7,4 +7,5 @@ function(cfg)
                if_enabled("dashboard", (import "dashboard/dashboard.jsonnet")(cfg)),
                if_enabled("heapster", (import "heapster/heapster.jsonnet")(cfg)),
                if_enabled("kube_dns", (import "kube-dns/kube-dns.jsonnet")(cfg)),
+               if_enabled("weave_net", (import "weave-net/weave-net.jsonnet")(cfg)),
              ]))

--- a/phase3/weave-net/weave-net-cluster-role-binding.json
+++ b/phase3/weave-net/weave-net-cluster-role-binding.json
@@ -1,0 +1,19 @@
+{
+    "kind": "ClusterRoleBinding",
+    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "metadata": {
+        "name": "weave-net"
+    },
+    "roleRef": {
+        "apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
+        "name": "weave-net"
+    },
+    "subjects": [
+        {
+            "kind": "ServiceAccount",
+            "name": "weave-net",
+            "namespace": "kube-system"
+        }
+    ]
+}

--- a/phase3/weave-net/weave-net-cluster-role.json
+++ b/phase3/weave-net/weave-net-cluster-role.json
@@ -1,0 +1,37 @@
+{
+    "kind": "ClusterRole",
+    "apiVersion": "rbac.authorization.k8s.io/v1beta1",
+    "metadata": {
+        "name": "weave-net"
+    },
+    "rules": [
+        {
+            "apiGroups": [
+                ""
+            ],
+            "resources": [
+                "pods",
+                "namespaces",
+                "nodes"
+            ],
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ]
+        },
+        {
+            "apiGroups": [
+                "extensions"
+            ],
+            "resources": [
+                "networkpolicies"
+            ],
+            "verbs": [
+                "get",
+                "list",
+                "watch"
+            ]
+        }
+    ]
+}

--- a/phase3/weave-net/weave-net-daemon-set.json
+++ b/phase3/weave-net/weave-net-daemon-set.json
@@ -1,0 +1,133 @@
+{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "DaemonSet",
+    "metadata": {
+        "name": "weave-net",
+        "namespace": "kube-system"
+    },
+    "spec": {
+        "template": {
+            "metadata": {
+                "labels": {
+                    "name": "weave-net"
+                }
+            },
+            "spec": {
+                "hostNetwork": true,
+                "hostPID": true,
+                "containers": [
+                    {
+                        "name": "weave",
+                        "image": "weaveworks/weave-kube:1.9.4",
+                        "command": [
+                            "/home/weave/launch.sh"
+                        ],
+                        "livenessProbe": {
+                            "initialDelaySeconds": 30,
+                            "httpGet": {
+                                "host": "127.0.0.1",
+                                "path": "/status",
+                                "port": 6784
+                            }
+                        },
+                        "securityContext": {
+                            "privileged": true
+                        },
+                        "volumeMounts": [
+                            {
+                                "name": "weavedb",
+                                "mountPath": "/weavedb"
+                            },
+                            {
+                                "name": "cni-bin",
+                                "mountPath": "/host/opt"
+                            },
+                            {
+                                "name": "cni-bin2",
+                                "mountPath": "/host/home"
+                            },
+                            {
+                                "name": "cni-conf",
+                                "mountPath": "/host/etc"
+                            },
+                            {
+                                "name": "dbus",
+                                "mountPath": "/host/var/lib/dbus"
+                            },
+                            {
+                                "name": "lib-modules",
+                                "mountPath": "/lib/modules"
+                            }
+                        ],
+                        "resources": {
+                            "requests": {
+                                "cpu": "10m"
+                            }
+                        }
+                    },
+                    {
+                        "name": "weave-npc",
+                        "image": "weaveworks/weave-npc:1.9.4",
+                        "resources": {
+                            "requests": {
+                                "cpu": "10m"
+                            }
+                        },
+                        "securityContext": {
+                            "privileged": true
+                        }
+                    }
+                ],
+                "restartPolicy": "Always",
+                "tolerations": [
+                    {
+                        "key": "node-role.kubernetes.io/master",
+                        "effect": "NoSchedule"
+                    }
+                ],
+                "serviceAccountName": "weave-net",
+                "securityContext": {
+                    "seLinuxOptions": {
+                        "type": "spc_t"
+                    }
+                },
+                "volumes": [
+                    {
+                        "name": "weavedb",
+                        "emptyDir": {}
+                    },
+                    {
+                        "name": "cni-bin",
+                        "hostPath": {
+                            "path": "/opt"
+                        }
+                    },
+                    {
+                        "name": "cni-bin2",
+                        "hostPath": {
+                            "path": "/home"
+                        }
+                    },
+                    {
+                        "name": "cni-conf",
+                        "hostPath": {
+                            "path": "/etc"
+                        }
+                    },
+                    {
+                        "name": "dbus",
+                        "hostPath": {
+                            "path": "/var/lib/dbus"
+                        }
+                    },
+                    {
+                        "name": "lib-modules",
+                        "hostPath": {
+                            "path": "/lib/modules"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/phase3/weave-net/weave-net-service-account.json
+++ b/phase3/weave-net/weave-net-service-account.json
@@ -1,0 +1,8 @@
+{
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+        "name": "weave-net",
+        "namespace": "kube-system"
+    }
+}

--- a/phase3/weave-net/weave-net.jsonnet
+++ b/phase3/weave-net/weave-net.jsonnet
@@ -1,0 +1,7 @@
+function(cfg)
+  {
+    "weave-net-service-account.json": import "weave-net-service-account.json",
+    "weave-net-cluster-role.json": import "weave-net-cluster-role.json",
+    "weave-net-cluster-role-binding.json": import "weave-net-cluster-role-binding.json",
+    "weave-net-daemon-set.json": import "weave-net-daemon-set.json",
+  }

--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -4,7 +4,7 @@ set -eux -o pipefail
 apk add --update git build-base wget curl jq autoconf automake pkgconfig ncurses-dev libtool gperf flex bison ca-certificates python
 
 ## Install kubectl
-export KUBECTL_VERSION=1.4.0
+export KUBECTL_VERSION=1.6.0-beta.4
 wget https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl
 chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
Most likely, this addon will only be used by clusters using `kubeadm` for phase2 that require a CNI provider.

The json files were generated by fetching https://git.io/weave-kube-1.6 (which is multidoc yaml), breaking it apart into individual documents, and converting them to json.

Since `ClusterRole` and `ClusterRoleBinding` weren't supported by the older `kubectl` used in the Docker image, I also bumped its version.

CC @mikedanese 