### PR TITLE
Allow disabled addons to be omitted from .config

### DIFF
--- a/phase3/all.jsonnet
+++ b/phase3/all.jsonnet
@@ -1,5 +1,5 @@
 function(cfg)
-  local if_enabled(addon, manifest) = if cfg.phase3[addon] then manifest else {};
+  local if_enabled(addon, manifest) = if std.objectHas(cfg.phase3, addon) && cfg.phase3[addon] then manifest else {};
   local join(arr) = std.foldl(function(a, b) a + b, arr, {});
   if_enabled("run_addons",
              join([


### PR DESCRIPTION
When running `make config` or `make menuconfig`, options that are disabled don't necessarily go into .config with values of `n`. In some versions of kconfig-frontends, like the one in this repo's Docker image, comments get stored instead:

    # .phase3.dashboard is not set

Without this change, attempting to run `make addons` or even just `phase3/do gen` chokes on these values, since jsonnet can't find configuration for them. With the change, it treats addons omitted from .config as disabled.

This should also help upgrade-proof clients that automate the creation of .config, so upstream additions of new addons don't render old .config files broken.