### PR TITLE
phase2 - ignition - reverting etcd-container image back to  etcd:2.2.1

### DIFF
--- a/phase2/ignition/vanilla/manifest/etcd.jsonnet
+++ b/phase2/ignition/vanilla/manifest/etcd.jsonnet
@@ -11,7 +11,7 @@ function(cfg)
       containers: [
         {
           name: "etcd-container",
-          image: "gcr.io/google_containers/etcd:3.0.4",
+          image: "gcr.io/google_containers/etcd:2.2.1",
           resources: {
             requests: {
               cpu: "200m",

--- a/phase2/ignition/vanilla/manifest/kube-apiserver.jsonnet
+++ b/phase2/ignition/vanilla/manifest/kube-apiserver.jsonnet
@@ -35,7 +35,7 @@ function(cfg)
               "--tls-cert-file=/srv/kubernetes/apiserver.pem",
               "--tls-private-key-file=/srv/kubernetes/apiserver-key.pem",
               "--secure-port=443",
-              "--storage-backend=etcd3", 
+              "--storage-backend=etcd2", 
               "--allow-privileged",
               "--v=4",
             ],


### PR DESCRIPTION
With the ignition image having` etcd:3.0.4`, we have observed issue, volume can not be detached from the node after pod is deleted. 

This issue is producible on Kubernetes Release **v1.5.3**,  which is working fine with `etcd:2.2.1`.

Issue is verified with creating two ignition images, and using same Kubernetes releases - 1.5.3

> divyen/ignition.etcd-3.0.4:v1 - disk never get detached from node VM, after pod is deleted.
> divyen/ignition.etcd-2.2.1:v1 - disk get detached from the node VM, after pod is deleted.

@tusharnt @BaluDontu @abrarshivani 




