### PR TITLE
Add Flannel network add-on

### DIFF
--- a/phase3/Kconfig
+++ b/phase3/Kconfig
@@ -38,6 +38,12 @@ config phase3.weave_net
 	default n
 	help
 	  Should we deploy weave-net? You likely only want this if using kubeadm for phase2.
+
+config phase3.flannel
+	bool "Run flannel?"
+	default n
+	help
+	  Should we deploy flannel? You likely only want this if using kubeadm for phase2.
 endif
 
 endmenu

--- a/phase3/all.jsonnet
+++ b/phase3/all.jsonnet
@@ -8,4 +8,5 @@ function(cfg)
                if_enabled("heapster", (import "heapster/heapster.jsonnet")(cfg)),
                if_enabled("kube_dns", (import "kube-dns/kube-dns.jsonnet")(cfg)),
                if_enabled("weave_net", (import "weave-net/weave-net.jsonnet")(cfg)),
+               if_enabled("flannel", (import "flannel/flannel.jsonnet")(cfg)),
              ]))

--- a/phase3/flannel/flannel-config-map.json
+++ b/phase3/flannel/flannel-config-map.json
@@ -1,0 +1,16 @@
+{
+  "kind": "ConfigMap",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "kube-flannel-cfg",
+    "namespace": "kube-system",
+    "labels": {
+      "tier": "node",
+      "app": "flannel"
+    }
+  },
+  "data": {
+    "cni-conf.json": "{\n  \"name\": \"cbr0\",\n  \"type\": \"flannel\",\n  \"delegate\": {\n    \"isDefaultGateway\": true\n  }\n}\n",
+    "net-conf.json": "{\n  \"Network\": \"10.244.0.0/16\",\n  \"Backend\": {\n    \"Type\": \"vxlan\"\n  }\n}"
+  }
+}

--- a/phase3/flannel/flannel-daemon-set.json
+++ b/phase3/flannel/flannel-daemon-set.json
@@ -1,0 +1,117 @@
+{
+  "apiVersion": "extensions/v1beta1",
+  "kind": "DaemonSet",
+  "metadata": {
+    "name": "kube-flannel-ds",
+    "namespace": "kube-system",
+    "labels": {
+      "tier": "node",
+      "app": "flannel"
+    }
+  },
+  "spec": {
+    "template": {
+      "metadata": {
+        "labels": {
+          "tier": "node",
+          "app": "flannel"
+        }
+      },
+      "spec": {
+        "hostNetwork": true,
+        "nodeSelector": {
+          "beta.kubernetes.io/arch": "amd64"
+        },
+        "tolerations": [
+          {
+            "key": "node-role.kubernetes.io/master",
+            "operator": "Exists",
+            "effect": "NoSchedule"
+          }
+        ],
+        "serviceAccountName": "flannel",
+        "containers": [
+          {
+            "name": "kube-flannel",
+            "image": "quay.io/coreos/flannel:v0.7.1-amd64",
+            "command": [
+              "/opt/bin/flanneld",
+              "--ip-masq",
+              "--kube-subnet-mgr"
+            ],
+            "securityContext": {
+              "privileged": true
+            },
+            "env": [
+              {
+                "name": "POD_NAME",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.name"
+                  }
+                }
+              },
+              {
+                "name": "POD_NAMESPACE",
+                "valueFrom": {
+                  "fieldRef": {
+                    "fieldPath": "metadata.namespace"
+                  }
+                }
+              }
+            ],
+            "volumeMounts": [
+              {
+                "name": "run",
+                "mountPath": "/run"
+              },
+              {
+                "name": "flannel-cfg",
+                "mountPath": "/etc/kube-flannel/"
+              }
+            ]
+          },
+          {
+            "name": "install-cni",
+            "image": "quay.io/coreos/flannel:v0.7.1-amd64",
+            "command": [
+              "/bin/sh",
+              "-c",
+              "set -e -x; cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conf; while true; do sleep 3600; done"
+            ],
+            "volumeMounts": [
+              {
+                "name": "cni",
+                "mountPath": "/etc/cni/net.d"
+              },
+              {
+                "name": "flannel-cfg",
+                "mountPath": "/etc/kube-flannel/"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "run",
+            "hostPath": {
+              "path": "/run"
+            }
+          },
+          {
+            "name": "cni",
+            "hostPath": {
+              "path": "/etc/cni/net.d"
+            }
+          },
+          {
+            "name": "flannel-cfg",
+            "configMap": {
+              "name": "kube-flannel-cfg"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/phase3/flannel/flannel-service-account.json
+++ b/phase3/flannel/flannel-service-account.json
@@ -1,0 +1,8 @@
+{
+  "apiVersion": "v1",
+  "kind": "ServiceAccount",
+  "metadata": {
+    "name": "flannel",
+    "namespace": "kube-system"
+  }
+}

--- a/phase3/flannel/flannel.jsonnet
+++ b/phase3/flannel/flannel.jsonnet
@@ -1,0 +1,6 @@
+function(cfg)
+  {
+    "flannel-service-account.json": import "flannel-service-account.json",
+    "flannel-config-map.json": import "flannel-config-map.json",
+    "flannel-daemon-set.json": import "flannel-daemon-set.json",
+  }


### PR DESCRIPTION
This implements the Flannel addon as a first step to adding better CNI coverage to kubeadm's e2e tests, as documented here https://github.com/kubernetes/kubeadm/issues/218. 

Unfortunately I wasn't able to verify this because I don't have a GCE or Azure account, nor a Vsphere license. Is there any way to get around this, or use some kind of community account? Alternatively is there any word on AWS, Vagrant or OpenStack providers? If not, I can see about getting GCE access.