### PR TITLE
Update terraform to 0.9.4

### DIFF
--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -209,5 +209,4 @@ function(cfg)
         },
       },
     } + tf.pki.cluster_tls_resources(p1.cluster_name, [names.master_instance], ["${google_compute_address.%(master_ip)s.address}" % names]),
-    data: tf.pki.cluster_tls_data(p1.cluster_name, [names.master_instance], ["${google_compute_address.%(master_ip)s.address}" % names]),
   }

--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -17,8 +17,7 @@ cp jsonnet /usr/local/bin)
 rm -rf /tmp/jsonnet
 
 ## Install Terraform
-export TERRAFORM_VERSION=0.7.2
-export TERRAFORM_SHA256SUM=b337c885526a8a653075551ac5363a09925ce9cf141f4e9a0d9f497842c85ad5
+export TERRAFORM_VERSION=0.9.4
 
 mkdir -p /tmp/terraform/
 (cd /tmp/terraform


### PR DESCRIPTION
This updates the Terraform version used by project from 0.7.2 to 0.9.4. It fixes multiple issues related to Terraform (see : https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md). 

- As the cert request flow changed after the 0.7.5 version, the jsonnet had to be updated to reflect this change. 
- The env variable TERRAFORM_SHA256SUM was also deleted from the docker-build script as it wasn't used. 