### PR TITLE
Don't add --kubernetes-version if the value is empty.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -27,7 +27,11 @@ fi
 
 case "${ROLE}" in
   "master")
-    kubeadm init --token "${TOKEN}" --apiserver-bind-port 443 --skip-preflight-checks --apiserver-advertise-address "$(get_metadata "k8s-advertise-addresses")" --kubernetes-version $KUBERNETES_VERSION
+    OPTS=''
+    if [[ -n "$KUBERNETES_VERSION" ]]; then
+      OPTS="--kubernetes-version $KUBERNETES_VERSION"
+    fi
+    kubeadm init --token "${TOKEN}" --apiserver-bind-port 443 --skip-preflight-checks --apiserver-advertise-address "$(get_metadata "k8s-advertise-addresses")" $OPTS
     ;;
   "node")
     MASTER=$(get_metadata "k8s-master-ip")


### PR DESCRIPTION
This is important for some of our e2e tests to be able to exercise the default behavior of omitting this parameter.