### PR TITLE
In GCE, make sure apt-transport-https is installed.

### DIFF
--- a/phase1/gce/configure-vm.sh
+++ b/phase1/gce/configure-vm.sh
@@ -14,6 +14,9 @@ get_metadata() {
 
 ROLE=$(get_metadata "k8s-role")
 
+apt-get update
+apt-get install -y apt-transport-https
+
 cat <<EOF > /etc/apt/sources.list.d/k8s.list
 deb [arch=amd64] https://apt.dockerproject.org/repo ubuntu-xenial main
 EOF


### PR DESCRIPTION
I found that this step was required when testing with a Debian image (debian-8-jessie-v20170426), and it's also one the steps in the [kubeadm getting started guide](https://kubernetes.io/docs/getting-started-guides/kubeadm/).

This doesn't actually allow the Debian image to be used end-to-end, since there are still dependency conflicts with the Docker package, but it does allow the startup to get a little further.