### PR TITLE
Turn off verbose output for untar

### DIFF
--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -49,7 +49,7 @@ export GOOGLE_SDK_VERSION=148.0.1
 mkdir -p /tmp/google-sdk
 (cd /tmp/google-sdk
 wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz
-tar xvf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /
+tar xf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /
 /google-cloud-sdk/install.sh -q --path-update true
 source ~/.bashrc
 )


### PR DESCRIPTION
Untarring with verbose produces hundreds of lines of output which seems a bit unnecessary and makes it harder to process what the scripts are doing for newcomers. 