### PR TITLE
Enable make Docker-Dev behind corporate proxy 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,22 @@ do:
 	( cd "phase1/$$(jq -r '.phase1.cloud_provider' .config.json)"; ./do $(WHAT) )
 
 docker-build:
-	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
+	docker build \
+		--build-arg="http_proxy=$(http_proxy)" \
+		--build-arg="https_proxy=$(https_proxy)" \
+		--build-arg="no_proxy=$(no_proxy)" \
+		--rm -t $(IMAGE_NAME):$(IMAGE_VERSION) .
 
-docker-dev: docker-build
+docker-dev: docker-build 
 	${info Starting Kuberetes Anywhere deployment shell in a container}
-	docker run -it --rm --env="PS1=[container]:\w> " --net=host --volume="`pwd`:/opt/kubernetes-anywhere" $(IMAGE_NAME):$(IMAGE_VERSION) /bin/bash
+	docker run -it --rm \
+		--env="PS1=[container]:\w> " \
+		--env="http_proxy=$(http_proxy)" \
+		--env="https_proxy=$(https_proxy)" \
+		--env="no_proxy=$(no_proxy)" \
+		--net=host \
+		--volume="`pwd`:/opt/kubernetes-anywhere" \
+		$(IMAGE_NAME):$(IMAGE_VERSION) /bin/bash
 
 docker-push: docker-build
 	docker push $(IMAGE_NAME):$(IMAGE_VERSION)

--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -29,6 +29,10 @@ unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin)
 rm -rf /tmp/terraform
 
 ## Install azure-xplat-cli
+if [ -n "$http_proxy" ]; then
+    npm config set strict-ssl false
+    npm config set proxy "${http_proxy}"
+fi
 npm install -g azure-cli
 
 ## Install kconfig-conf


### PR DESCRIPTION
improve `make docker-dev`making it sensible to proxy.

if env vars (http_proxy, https_proxy, no_proxy) are set, those variables will be forwarded to `docker build`, `docker run` (and `npm` inside docker).

NB. tested only on GCE (also changes for enabling same functionality on Azure, but not tested yet)

