### PR TITLE
Deploy multiple clusters from same workspace

### DIFF
--- a/phase1/azure/README.md
+++ b/phase1/azure/README.md
@@ -78,7 +78,7 @@ You'll need to do this outside of the `kubernetes-anywhere` deployment environme
 
 ```shell
 mkdir -p ~/.kube
-cp ./phase1/azure/.tmp/kubeconfig.json ~/.kube/config
+cp $(make -s kubeconfig-path) ~/.kube/config
 ```
 
 

--- a/phase1/azure/azure.jsonnet
+++ b/phase1/azure/azure.jsonnet
@@ -273,7 +273,7 @@ function(config)
         kubeconfig: {
           provisioner: [{
             "local-exec": {
-              command: "echo '%s' > ./.tmp/kubeconfig.json" % kubeconfig(cfg.cluster_name + "-admin", cfg.cluster_name, cfg.cluster_name),
+              command: "echo '%s' > %s/kubeconfig.json" % [ kubeconfig(cfg.cluster_name + "-admin", cfg.cluster_name, cfg.cluster_name), cfg.cluster_name ],
             },
           }],
         },

--- a/phase1/azure/do
+++ b/phase1/azure/do
@@ -8,9 +8,12 @@ cd "${BASH_SOURCE%/*}"
 config="./../../.config"
 configjson="./../../.config.json"
 
+CLUSTER_NAME=$(jq -r '.phase1.cluster_name' ${configjson})
+TMP_DIR=${CLUSTER_NAME}/.tmp
+
 gen() {
-  mkdir -p .tmp/
-  jsonnet -J ../../ --multi .tmp/ all.jsonnet
+  mkdir -p ${TMP_DIR}
+  jsonnet -J ../../ --multi ${TMP_DIR}/ all.jsonnet
 }
 
 check_auth() {
@@ -102,15 +105,15 @@ deploy() {
   gen
 
   # Workaround: https://github.com/hashicorp/terraform/issues/7153
-  terraform apply -state=./.tmp/terraform.tfstate .tmp ||
-    terraform apply -state=./.tmp/terraform.tfstate .tmp
+  terraform apply -state=${CLUSTER_NAME}/terraform.tfstate ${TMP_DIR} ||
+    terraform apply -state=${CLUSTER_NAME}/terraform.tfstate ${TMP_DIR}
 }
 
 destroy() {
   if [[ "${FORCE_DESTROY:-}" == "y" ]]; then
-    terraform destroy -state=./.tmp/terraform.tfstate -force .tmp
+    terraform destroy -state=${CLUSTER_NAME}/terraform.tfstate -force ${TMP_DIR}
   else
-    terraform destroy -state=./.tmp/terraform.tfstate .tmp
+    terraform destroy -state=${CLUSTER_NAME}/terraform.tfstate ${TMP_DIR}
   fi
 }
 

--- a/phase1/gce/README.md
+++ b/phase1/gce/README.md
@@ -53,7 +53,7 @@ $ make deploy
 and fill complete the config wizard to deploy a kubernetes-anywhere cluster. Eventually, you will see a set of nodes when you run:
 
 ```console
-$ kubectl --kubeconfig phase1/gce/kubeconfig.json get nodes
+$ kubectl --kubeconfig $(make -s kubeconfig-path) get nodes
 ```
 
 It may take a couple minutes for the Kubernetes API to start responding to requests.

--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -54,7 +54,7 @@ fetch_kubeconfig() {
     # a marker to indicate the start of the file, and delete all lines up to and
     # including it.
     if gcloud compute ssh --project "$PROJECT" --zone "$ZONE" "$MASTER" --command "echo STARTFILE; sudo cat /etc/kubernetes/admin.conf" > ${TMP_DIR}/kubeconfig.raw; then
-      sed '0,/^STARTFILE$/d' ${TMP_DIR}/kubeconfig.raw > ${CLUSTER_NAME}/kubeconfig.json
+      sed '/^STARTFILE$/,$!d;/^STARTFILE$/d' ${TMP_DIR}/kubeconfig.raw > ${CLUSTER_NAME}/kubeconfig.json
       echo Successfully fetched kubeconfig.
       return
     else

--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -7,20 +7,23 @@ set -x
 
 cd "${BASH_SOURCE%/*}"
 
+CLUSTER_NAME=$(jq -r '.phase1.cluster_name' ../../.config.json)
+TMP_DIR=${CLUSTER_NAME}/.tmp
+
 generate_token() {
   perl -e 'printf "%06x.%08x%08x\n", rand(0xffffff), rand(0xffffffff), rand(0xffffffff);'
 }
 
 gen() {
   TOKEN=$(generate_token)
-  mkdir -p .tmp/
-  jsonnet -J ../../ --multi .tmp/ all.jsonnet
-  echo "kubeadm_token = \"$TOKEN\"" > .tmp/terraform.tfvars
+  mkdir -p ${TMP_DIR}
+  jsonnet -J ../../ --multi ${TMP_DIR} all.jsonnet
+  echo "kubeadm_token = \"$TOKEN\"" > ${CLUSTER_NAME}/terraform.tfvars
 }
 
 deploy() {
   gen
-  terraform apply -var-file .tmp/terraform.tfvars .tmp
+  terraform apply -var-file=${CLUSTER_NAME}/terraform.tfvars -state=${CLUSTER_NAME}/terraform.tfstate ${TMP_DIR}
 
   if [[ "${WAIT_FOR_KUBECONFIG:-}" == "y" ]]; then
     fetch_kubeconfig
@@ -50,8 +53,8 @@ fetch_kubeconfig() {
     # succeeds, then stdout is tainted by ssh initialization output, so we echo
     # a marker to indicate the start of the file, and delete all lines up to and
     # including it.
-    if gcloud compute ssh --project "$PROJECT" --zone "$ZONE" "$MASTER" --command "echo STARTFILE; sudo cat /etc/kubernetes/admin.conf" > .tmp/kubeconfig.raw; then
-      sed '0,/^STARTFILE$/d' .tmp/kubeconfig.raw > .tmp/kubeconfig.json
+    if gcloud compute ssh --project "$PROJECT" --zone "$ZONE" "$MASTER" --command "echo STARTFILE; sudo cat /etc/kubernetes/admin.conf" > ${TMP_DIR}/kubeconfig.raw; then
+      sed '0,/^STARTFILE$/d' ${TMP_DIR}/kubeconfig.raw > ${CLUSTER_NAME}/kubeconfig.json
       echo Successfully fetched kubeconfig.
       return
     else
@@ -68,7 +71,7 @@ destroy() {
   if [[ "${FORCE_DESTROY:-}" == "y" ]]; then
     FLAGS="-force"
   fi
-  terraform destroy -var-file .tmp/terraform.tfvars $FLAGS .tmp
+  terraform destroy -var-file=${CLUSTER_NAME}/terraform.tfvars -state=${CLUSTER_NAME}/terraform.tfstate $FLAGS ${TMP_DIR}
 }
 
 case "${1:-}" in

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -8,6 +8,7 @@ function(cfg)
     instance_group: "%(cluster_name)s-node-group" % p1,
     master_instance: "%(cluster_name)s-master" % p1,
     master_ip: "%(cluster_name)s-master-ip" % p1,
+    ssh_all: "%(cluster_name)s-ssh-all" % p1,
     master_external_firewall_rule: "%(cluster_name)s-master-https" % p1,
     master_internal_firewall_rule: "%(cluster_name)s-master-internal" % p1,
     node_firewall_rule: "%(cluster_name)s-node-all" % p1,
@@ -74,7 +75,7 @@ function(cfg)
         },
       },
       google_compute_firewall: {
-        ssh_all: {
+        [names.ssh_all]: {
           name: "%(cluster_name)s-ssh-all" % p1,
           network: gce.network,
           allow: [{
@@ -203,7 +204,7 @@ function(cfg)
         kubeconfig: {
           provisioner: [{
             "local-exec": {
-              command: "echo '%s' > .tmp/kubeconfig.json" % kubeconfig(p1.cluster_name + "-admin", p1.cluster_name, p1.cluster_name),
+              command: "echo '%s' > %s/kubeconfig.json" % [ kubeconfig(p1.cluster_name + "-admin", p1.cluster_name, p1.cluster_name), p1.cluster_name ],
             },
           }],
         },

--- a/phase1/vsphere/README.md
+++ b/phase1/vsphere/README.md
@@ -267,7 +267,7 @@ Make sure to create a new resource pool and give a different cluster name.
 First set KUBECONFIG to access cluster using kubectl:
 
 ```shell
-export KUBECONFIG=phase1/vsphere/.tmp/kubeconfig.json
+export KUBECONFIG=$(make -s kubeconfig-path)
 ```
 
 You will get cluster information when you run:
@@ -285,7 +285,7 @@ curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.6.5/bin/li
 chmod u+x kubectl
 mdkir ~/.kube/
 cd  ~/.kube/
-vi config // copy content of phase1/vsphere/.tmp/kubeconfig.json and paste in this file.
+vi config // copy content of $(make -s kubeconfig-path) and paste in this file.
 export KUBECONFIG=~/.kube/config
 ./kubectl proxy
 Starting to serve on 127.0.0.1:8001

--- a/phase1/vsphere/do
+++ b/phase1/vsphere/do
@@ -5,17 +5,19 @@ set -o pipefail
 set -o nounset
 
 cd "${BASH_SOURCE%/*}"
-f="./../../.config.json"
+
+CLUSTER_NAME=$(jq -r '.phase1.cluster_name' ../../.config.json)
+TMP_DIR=${CLUSTER_NAME}/.tmp
 
 gen() {
-  mkdir -p .tmp/
-  jsonnet -J ../../ --multi .tmp/ all.jsonnet
+  mkdir -p ${TMP_DIR}
+  jsonnet -J ../../ --multi ${TMP_DIR} all.jsonnet
 }
 
 
 deploy() {
   gen
-  terraform apply -state=./.tmp/terraform.tfstate .tmp
+  terraform apply -state=${CLUSTER_NAME}/terraform.tfstate ${TMP_DIR}
   COMMAND="grep '.phase2.kubernetes_version' ../../.config | cut -d '=' -f2 | tr -d '\"'"
   KUBERNETES_VERSION=$(eval $COMMAND)
   # If the kubectl binary doesn't exist download it.
@@ -40,9 +42,9 @@ deploy() {
 
 destroy() {
   if [[ "${FORCE_DESTROY:-}" == "y" ]]; then
-    terraform destroy -state=./.tmp/terraform.tfstate -force .tmp
+    terraform destroy -state=${CLUSTER_NAME}/terraform.tfstate -force ${TMP_DIR}
   else
-    terraform destroy -state=./.tmp/terraform.tfstate .tmp
+    terraform destroy -state=${CLUSTER_NAME}/terraform.tfstate ${TMP_DIR}
   fi
 }
 

--- a/phase1/vsphere/vSphere.jsonnet
+++ b/phase1/vsphere/vSphere.jsonnet
@@ -142,7 +142,7 @@ function(config)
                 }
            }, {
             "local-exec": {
-              command: "echo '%s' > ./.tmp/kubeconfig.json" % kubeconfig(cfg.cluster_name + "-admin", cfg.cluster_name, cfg.cluster_name),
+              command: "echo '%s' > %s/kubeconfig.json" % [ kubeconfig(cfg.cluster_name + "-admin", cfg.cluster_name, cfg.cluster_name), cfg.cluster_name ],
             },
            }],
         },} + {

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -1,16 +1,6 @@
 
 menu "Phase 2: Node Bootstrapping"
 
-config phase2.installer_container
-	string "installer container"
-	default "docker.io/cnastorage/k8s-ignition:v2"
-
-config phase2.docker_registry
-	string "docker registry"
-	default "gcr.io/google-containers"
-	help
-	  The docker registry to pull cluster components from.
-
 config phase2.kubernetes_version
 	string "kubernetes version"
 	default "v1.6.5"
@@ -24,6 +14,20 @@ config phase2.provider
 	  The bootstrap provider to use.
 
 	  Valid options are (ignition, kubeadm).
+
+if phase2.provider = ignition
+
+config phase2.installer_container
+	string "installer container"
+	default "docker.io/cnastorage/k8s-ignition:v2"
+
+config phase2.docker_registry
+	string "docker registry"
+	default "gcr.io/google-containers"
+	help
+	  The docker registry to pull cluster components from.
+
+endif
 
 if phase2.provider = kubeadm
 

--- a/phase3/do
+++ b/phase3/do
@@ -5,16 +5,19 @@ set -o pipefail
 set -o nounset
 set -x
 
+cd "${BASH_SOURCE%/*}"
+
+TMP_DIR=$(jq -r '.phase1.cluster_name' ../.config.json)/.tmp
+
 gen() {
-	cd "${BASH_SOURCE%/*}"
-	mkdir -p .tmp/
-	jsonnet --multi .tmp/ --tla-code-file cfg=../.config.json all.jsonnet
+	mkdir -p ${TMP_DIR}
+	jsonnet --multi ${TMP_DIR} --tla-code-file cfg=../.config.json all.jsonnet
 }
 
 deploy() {
 	gen
 	mkdir -p /tmp/kubectl/
-	HOME=/tmp/kubectl kubectl apply -f ./.tmp/
+	HOME=/tmp/kubectl kubectl apply -f ./${TMP_DIR}
 }
 
 

--- a/test/azure/Jenkinsfile
+++ b/test/azure/Jenkinsfile
@@ -99,12 +99,12 @@ node {
 				archiveArtifacts artifacts: 'config.json', fingerprint: true
 
 				sh("make deploy")
-				sh("cp ./phase1/azure/.tmp/kubeconfig.json ./kubeconfig.json")
+				sh("cp ./phase1/azure/${clusterName}/kubeconfig.json ./kubeconfig.json")
 				archiveArtifacts artifacts: 'kubeconfig.json', fingerprint: true
 
 				if (testCluster=="y") {
 					stage 'Test Cluster'
-					withEnv(['KUBECONFIG=' + cwd() + '/phase1/azure/.tmp/kubeconfig.json']) {
+					withEnv(['KUBECONFIG=' + cwd() + "/phase1/azure/${clusterName}/kubeconfig.json"]) {
 						make conformtest
 					}
 				}

--- a/util/docker-build.sh
+++ b/util/docker-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
 
-apk add --update git build-base wget curl jq autoconf automake pkgconfig ncurses-dev libtool gperf flex bison ca-certificates python
+apk add --update git build-base wget curl jq autoconf automake pkgconfig ncurses-dev libtool gperf flex bison ca-certificates python openssh-client
 
 ## Install kubectl
 export KUBECTL_VERSION=1.6.0-beta.4


### PR DESCRIPTION
This PR enables deploying multiple clusters from the same workspace without affecting each other.
- .tmp directory is moved to a directory with name <cluster_name>
- kubeconfig.json is stored in <cluster_name> directory instead of .tmp directory.

We could bring-up multiple clusters with the changes in this PR sequentially, bringing them up in parallel needs some more modifications.

This is done as part of effort to migrate federation cluster bring-up method to k8s-anywhere   Ref: https://github.com/kubernetes/test-infra/issues/3858

The environment supposed to be used in test-infra is `gce+kubeadm+weavenet` and this PR has been tested in this environment.
The other 2 environments azure and vsphere has not been tested, but are minor changes and can be reviewed.

/assign @pipejakob 
/assign @luxas 
/cc @madhusudancs 