### PR TITLE
Allow user to specify VM folder Path where Node VMs needs to be placed

### DIFF
--- a/phase1/vsphere/Kconfig
+++ b/phase1/vsphere/Kconfig
@@ -75,6 +75,12 @@ if phase1.vSphere.useresourcepool = "yes"
 			Resource Pool where kubernetes cluster will be deployed.
 endif
 
+config phase1.vSphere.vmfolderpath
+	string "VM Folder name or Path (e.g kubernetes, VMFolder1/dev-cluster, VMFolder1/Test Group1/test-cluster)"
+	default "kubernetes"
+	help
+		VM Folder Path where Node VMs should be placed.
+
 config phase1.vSphere.vcpu
 	int "Number of vCPUs for each VM"
 	default 1

--- a/phase1/vsphere/vSphere.jsonnet
+++ b/phase1/vsphere/vSphere.jsonnet
@@ -81,7 +81,7 @@ function(config)
             allow_unverified_ssl: std.escapeStringJson(cfg.vSphere.insecure),
             datacenter: std.escapeStringJson(cfg.vSphere.datacenter),
             datastore: std.escapeStringJson(cfg.vSphere.datastore),
-            working_dir: std.escapeStringJson(cfg.cluster_name),
+            working_dir: std.escapeStringJson(cfg.vSphere.vmfolderpath),
           },
         },
       },
@@ -92,7 +92,7 @@ function(config)
       "vsphere_folder":{
         "cluster_folder": {
           datacenter: cfg.vSphere.datacenter, 
-          path: cfg.cluster_name,
+          path: cfg.vSphere.vmfolderpath,
         },
       },
       vsphere_virtual_machine: {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes-anywhere/issues/422

Currently Kubernetes-Anywhere asks user to specify the name of the cluster and then uses this name to create vm folder on the root. Node VMs are then placed on this folder.

Customer requested to prompt menu option to specify VM folder path where cluster needs to be deployed.

This PR addressed above customer request.

**New menu options looks like as below.**


`VM Folder name or Path (e.g kubernetes, VMFolder1/dev-cluster, VMFolder1/Test Group1/test-cluster) (phase1.vSphere.vmfolderpath) [kubernetes] (NEW) divyen/kubernetes`

**Testing:**

`.phase1.vSphere.vmfolderpath="divyenp/kubernetes/Test Cluster"`
In this case 
VM Folders divyenp and sub folders were not present, folder structure is created by kubernetes-anywhere and cluster deployed successfully


`.phase1.vSphere.vmfolderpath="divyenp/kubernetes"`
In this case VM Folder: divyenp/kubernetes was already present. Cluster deployed successfully.


` .phase1.vSphere.vmfolderpath="divyenp/kubernetes/Test Cluster"`
In this case VM Folder :divyenp/kubernetes was present, but folder "Test Cluster" (with space) did not exist, this folder is created by kubernetes-anywhere and cluster deployed successfully.


Please review : @rohitjogvmw @BaluDontu @luomiao @tusharnt
