### PR TITLE
If phase1.ssh_user isn't set, also try to use $USER.

### DIFF
--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -46,6 +46,8 @@ fetch_kubeconfig() {
 
   if [[ -n "${SSHUSER}" ]]; then
     SSHUSER="${SSHUSER}@"
+  elif [[ -n "${USER:-}" ]]; then
+    SSHUSER="${USER}@"
   fi
 
   for tries in {1..60}; do


### PR DESCRIPTION
If the .config file is missing `phase1.ssh_user`, we should still attempt to explicitly use `$USER@host` to avoid the poorly documented default behavior of gcloud looking up the user from the service account (which is wrong, in prow's case):

https://github.com/kubernetes/kubeadm/issues/219

If `$USER` is unset, like it is in the `make docker-dev` environment, then we can still fall back to omitting the `user@` portion of the ssh command. But, this will make it a little friendlier to use in other environments.