### PR TITLE
Fix binding of TLS resources for ignition.

### DIFF
--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -211,5 +211,6 @@ function(cfg)
           }],
         },
       },
-    } else { } + if p2.provider != "kubeadm" then tf.pki.cluster_tls_resources(p1.cluster_name, [names.master_instance], ["${google_compute_address.%(master_ip)s.address}" % names]) else { },
+    } + tf.pki.cluster_tls_resources(p1.cluster_name, [names.master_instance], ["${google_compute_address.%(master_ip)s.address}" % names])
+    else { },
   }


### PR DESCRIPTION
`gce.jsonnet` was recently refactored to skip elements that aren't needed based on the `phase2.provider`. However, based on jsonnet's parsing, the second of the two `if` statements was being appending to the `else { }` block of the previous `if`, and so it was being short-circuited entirely instead of independently evaluated.

The intent of the code was to logically do:

    if condition1 {
      append(X)
    }
    if condition2 {
      append(Y)
    }

but based on jsonnet's list append binding, it was actually doing:

    if condition1 {
      append(X)
    }
    else if condition2 {
      append(Y)
    }

Since `condition1` and `condition2` are identical here, rather than two separate `if`s I've merged them into a single one. I've tested to ensure that in the case of ignition, both the `null_resource` and TLS resources are included, and in the case of kubeadm, both are excluded.

This fixes https://github.com/kubernetes/kubernetes-anywhere/issues/434.