### PR TITLE
Fix validate for node readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,16 @@ kubeconfig-path: ${CONFIG_JSON_FILE}
 	fi
 	@echo $(KUBECONFIG_PATH)
 
-validate: ${CONFIG_JSON_FILE}
+validate-cluster-up: ${CONFIG_JSON_FILE}
 	KUBECONFIG="$$(pwd)/phase1/$(CLOUD_PROVIDER)/$(CLUSTER_NAME)/kubeconfig.json" ./util/validate
+
+validate-node-ready: ${CONFIG_JSON_FILE}
+	KUBECONFIG="$$(pwd)/phase1/$(CLOUD_PROVIDER)/$(CLUSTER_NAME)/kubeconfig.json" NODE_READINESS_CHECK=y ./util/validate
 
 addons: ${CONFIG_JSON_FILE}
 	KUBECONFIG="$$(pwd)/phase1/$(CLOUD_PROVIDER)/$(CLUSTER_NAME)/kubeconfig.json" ./phase3/do deploy
 
-deploy: | deploy-cluster validate addons
+deploy: | deploy-cluster  validate-cluster-up  addons  validate-node-ready
 destroy: | destroy-cluster
 
 do:

--- a/util/validate
+++ b/util/validate
@@ -10,10 +10,17 @@ total_time=0
 wait_duration=10
 num_nodes="$(( $(cat ${CONFIG_FILE} | jq -r '.phase1.num_nodes') + 1 ))"
 
+search_string='Ready' # Matches both 'Ready' and 'NotReady' nodes.
+output_string='nodes'
+if [[ "${NODE_READINESS_CHECK:-}" == "y" ]]; then
+  search_string=' Ready ' # Only matches 'Ready' nodes.
+  output_string='healthy nodes'
+fi
+
 while true; do
   total_time=$(( ${total_time} + ${wait_duration} ))
-  hcount=$(kubectl get nodes 2>/dev/null | grep 'Ready' | wc -l) || true
-  echo "Validation: Expected ${num_nodes} (workers + master) healthy nodes; found ${hcount}. (${total_time}s elapsed)"
+  hcount=$(kubectl get nodes 2>/dev/null | grep ${search_string} | wc -l) || true
+  echo "Validation: Expected ${num_nodes} (workers + master) ${output_string}; found ${hcount}. (${total_time}s elapsed)"
 
   [[ "${hcount}" -ge "${num_nodes}" ]] && echo "Validation: Success!" && exit
 


### PR DESCRIPTION
Current implementation fails to check if node is in ready condition after deployment.
To fix the issue, the validate script is updated to check for both cluster-readiness and node-readiness.

/assign @pipejakob 
/cc @luxas 