### PR TITLE
Enable cloud-provider in GCE based deployments.

### DIFF
--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -192,7 +192,7 @@ function(cfg)
             boot: true,
           }],
           service_account: [
-            { scopes: ["compute-rw", "storage-ro"] },
+            { scopes: ["compute-rw", "storage-ro", "https://www.googleapis.com/auth/ndev.clouddns.readwrite"] },
           ],
         },
       },

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -151,6 +151,7 @@ function(cfg)
             "k8s-kubeadm-version": "%(version)s" % p2.kubeadm,
             "k8s-kubernetes-version": "%(kubernetes_version)s" % p2,
             "k8s-kubelet-version": "%(kubelet_version)s" % p2,
+            "k8s-enable-cloud-provider": (if std.objectHas(p2, "enable_cloud_provider") && p2.enable_cloud_provider then "true" else "false"),
           } else {
             "k8s-config": config_metadata_template % [names.master_ip, "master"],
             "k8s-ca-public-key": "${tls_self_signed_cert.%s-root.cert_pem}" % p1.cluster_name,
@@ -179,6 +180,7 @@ function(cfg)
             "k8s-kubeadm-version": "%(version)s" % p2.kubeadm,
             "k8s-kubernetes-version": "%(kubernetes_version)s" % p2,
             "k8s-kubelet-version": "%(kubelet_version)s" % p2,
+            "k8s-enable-cloud-provider": (if std.objectHas(p2, "enable_cloud_provider") && p2.enable_cloud_provider then "true" else "false"),
           } else {
             "k8s-deploy-bucket": names.release_bucket,
             "k8s-config": config_metadata_template % [names.master_ip, "node"],

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -64,6 +64,12 @@ config phase2.kube_context_name
 	  This is optional to set and when set, the kubeconfig
 	  context is renamed to whatever is configured.
 
+config phase2.enable_cloud_provider
+	bool "Enable Cloud Provider(Experimental) ?"
+	default n
+	help
+	  Should we enable and initialize cloud provider for the cluster?
+
 endif
 
 endmenu

--- a/phase2/kubeadm/do
+++ b/phase2/kubeadm/do
@@ -8,7 +8,7 @@ set -x
 cd "${BASH_SOURCE%/*}"
 
 CONFIG_FILE="${CONFIG_JSON_FILE:-../../.config.json}"
-KUBEADM_INIT_PARAM_FILE=/etc/kubeadm/kubeadm_init_params.txt
+KUBEADM_CONFIG_FILE=/etc/kubeadm/kubeadm.yaml
 
 upgrade_master() {
   KUBERNETES_VERSION=$(jq -r '.phase2.kubernetes_version' ${CONFIG_FILE})
@@ -18,13 +18,14 @@ upgrade_master() {
   update_host_kubeadm ${MASTER}
   validate
 
-  INIT_PARAM=$(execute_host ${MASTER} "sudo cat ${KUBEADM_INIT_PARAM_FILE}")
+  execute_host ${MASTER} "sudo sed -i \"s|^kubernetesVersion: .*|kubernetesVersion: \\\"${KUBERNETES_VERSION}\\\"|\" ${KUBEADM_CONFIG_FILE}"
+
   case "${UPGRADE_METHOD}" in
     "init")
-      execute_host ${MASTER} "sudo kubeadm init --skip-preflight-checks --kubernetes-version ${KUBERNETES_VERSION} ${INIT_PARAM}"
+      execute_host ${MASTER} "sudo kubeadm init --skip-preflight-checks --config ${KUBEADM_CONFIG_FILE}"
       ;;
     "upgrade")
-      execute_host ${MASTER} "sudo kubeadm config upload from-flags ${INIT_PARAM}"
+      execute_host ${MASTER} "sudo kubeadm config upload from-file --config ${KUBEADM_CONFIG_FILE}"
       execute_host ${MASTER} "sudo kubeadm upgrade apply ${KUBERNETES_VERSION} -y -f"
       ;;
   esac

--- a/phase3/Kconfig
+++ b/phase3/Kconfig
@@ -41,7 +41,7 @@ config phase3.weave_net
 
 		Should we deploy weave-net? You likely only want this if using kubeadm for phase2.
 
-if phase3.weave_net = false
+if phase3.weave_net = n
 config phase3.cni
 	string "CNI plugin to use"
 	default ""

--- a/phase3/Kconfig
+++ b/phase3/Kconfig
@@ -51,6 +51,15 @@ config phase3.cni
 		Valid options are (flannel, weave).
 endif
 
+if phase1.cloud_provider = gce
+config phase3.gce_storage_class
+	depends on phase2.enable_cloud_provider
+	bool "Deploy default storage class?"
+	default n
+	help
+	  Should we deploy default storage class for GCE?
+endif
+
 endif
 
 endmenu

--- a/phase3/all.jsonnet
+++ b/phase3/all.jsonnet
@@ -11,4 +11,5 @@ function(cfg)
                if_enabled("weave_net", (import "weave-net/weave-net.jsonnet")(cfg)),
                if_cni_plugin("weave", (import "weave-net/weave-net.jsonnet")(cfg)),
                if_cni_plugin("flannel", (import "flannel/flannel.jsonnet")(cfg)),
+               if_enabled("gce_storage_class", (import "gce-storage-class/storage-class.jsonnet")(cfg)),
              ]))

--- a/phase3/gce-storage-class/storage-class.json
+++ b/phase3/gce-storage-class/storage-class.json
@@ -1,0 +1,18 @@
+{
+  "kind": "StorageClass",
+  "apiVersion": "storage.k8s.io/v1",
+  "metadata": {
+    "name": "standard",
+    "annotations": {
+      "storageclass.beta.kubernetes.io/is-default-class": "true"
+    },
+    "labels": {
+      "addonmanager.kubernetes.io/mode": "EnsureExists",
+      "kubernetes.io/cluster-service": "true"
+    },
+  },
+  "parameters": {
+    "type": "pd-standard"
+  },
+  "provisioner": "kubernetes.io/gce-pd",
+}

--- a/phase3/gce-storage-class/storage-class.jsonnet
+++ b/phase3/gce-storage-class/storage-class.jsonnet
@@ -1,0 +1,4 @@
+function(cfg)
+  {
+    "storage-class.json": (import "storage-class.json"),
+  }


### PR DESCRIPTION
This PR is in continuation to migrate deployment mechanism used by federation to k8s-anywhere as listed out in https://github.com/kubernetes/test-infra/issues/3858. This is the 5th task in that series.

Federation CI jobs needs k8s clusters deployed with cloud-provider enabled for load-balancer type services and persistent volumes.

/cc @luxas @pipejakob @madhusudancs @kubernetes/sig-federation-pr-reviews 