### PR TITLE
Allow configuration for a kublet version that differs from kubeadm

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -3,28 +3,50 @@
 TOKEN=$(get_metadata "k8s-kubeadm-token")
 KUBEADM_VERSION=$(get_metadata "k8s-kubeadm-version")
 KUBERNETES_VERSION=$(get_metadata "k8s-kubernetes-version")
-
+KUBELET_VERSION=$(get_metadata "k8s-kubelet-version")
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
-if [[ "${KUBEADM_VERSION}" == stable ]]; then
+if [[ "${KUBELET_VERSION}" == stable ]]; then
   cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
   deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
-
   apt-get update
+  # kubeadm is installed with the kubelet so that the 
+  # kubelet has the configuration at a matching version
   apt-get install -y kubelet kubeadm kubectl kubernetes-cni
-elif [[ "${KUBEADM_VERSION}" == "gs://"* ]]; then
+elif [[ "${KUBELET_VERSION}" == "gs://"* ]]; then
   TMPDIR=/tmp/k8s-debs
   mkdir $TMPDIR
-  gsutil rsync "${KUBEADM_VERSION}" $TMPDIR
+  gsutil rsync "${KUBELET_VERSION}" $TMPDIR
+  # kubeadm is installed with the kubelet so that the 
+  # kubelet has the configuration at a matching version
   dpkg -i $TMPDIR/{kubelet,kubeadm,kubectl,kubernetes-cni}.deb || echo Ignoring expected dpkg failure
   apt-get install -f -y
   systemctl enable kubelet
   systemctl start kubelet
   rm -rf $TMPDIR
 else
-  echo "Don't know how to handle version: $KUBEADM_VERSION"
+  echo "Don't know how to handle kubelet version: $KUBELET_VERSION"
   exit 1
+fi
+
+if [[ "${KUBEADM_VERSION}" != "${KUBELET_VERSION}" ]]; then
+  if [[ "${KUBEADM_VERSION}" == stable ]]; then
+    # Cannot install packages as they will update the 
+    # kubelet configuration to a version that does not match
+    # the installed kubelet
+    echo "Kubeadm version of 'stable' is not supported with kubelet version that is not also 'stable'."
+    exit 1
+  elif [[ "${KUBEADM_VERSION}" == "gs://"* ]]; then
+    TMPDIR=/tmp/k8s-debs
+    mkdir $TMPDIR
+    gsutil cp "${KUBEADM_VERSION}/kubeadm" $TMPDIR/kubeadm
+    cat $TMPDIR/kubeadm > /usr/bin/kubeadm
+    rm -rf $TMPDIR
+  else
+    echo "Don't know how to handle kubeadm version: $KUBEADM_VERSION"
+    exit 1
+  fi
 fi
 
 case "${ROLE}" in

--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -41,7 +41,7 @@ if [[ "${KUBEADM_VERSION}" != "${KUBELET_VERSION}" ]]; then
     TMPDIR=/tmp/k8s-debs
     mkdir $TMPDIR
     gsutil cp "${KUBEADM_VERSION}/kubeadm" $TMPDIR/kubeadm
-    cat $TMPDIR/kubeadm > /usr/bin/kubeadm
+    cp $TMPDIR/kubeadm /usr/bin/kubeadm
     rm -rf $TMPDIR
   else
     echo "Don't know how to handle kubeadm version: $KUBEADM_VERSION"

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -147,7 +147,8 @@ function(cfg)
           } + if p2.provider == "kubeadm" then {
             "k8s-kubeadm-token": "${var.kubeadm_token}",
             "k8s-kubeadm-version": "%(version)s" % p2.kubeadm,
-            "k8s-kubernetes-version": "%(kubernetes_version)s" % p2
+            "k8s-kubernetes-version": "%(kubernetes_version)s" % p2,
+            "k8s-kubelet-version": "%(kubelet_version)s" % p2,
           } else {
             "k8s-config": config_metadata_template % [names.master_ip, "master"],
             "k8s-ca-public-key": "${tls_self_signed_cert.%s-root.cert_pem}" % p1.cluster_name,
@@ -174,7 +175,8 @@ function(cfg)
           } + if p2.provider == "kubeadm" then {
             "k8s-kubeadm-token": "${var.kubeadm_token}",
             "k8s-kubeadm-version": "%(version)s" % p2.kubeadm,
-            "k8s-kubernetes-version": "%(kubernetes_version)s" % p2
+            "k8s-kubernetes-version": "%(kubernetes_version)s" % p2,
+            "k8s-kubelet-version": "%(kubelet_version)s" % p2,
           } else {
             "k8s-deploy-bucket": names.release_bucket,
             "k8s-config": config_metadata_template % [names.master_ip, "node"],

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -5,7 +5,7 @@ config phase2.kubernetes_version
 	string "kubernetes version"
 	default "v1.6.5"
 	help
-	  The version of Kubernetes to deploy.
+	  The version of Kubernetes to deploy to the control plane.
 
 config phase2.provider
 	string "bootstrap provider"
@@ -36,6 +36,14 @@ config phase2.kubeadm.version
 	default "stable"
 	help
 	  The version of kubeadm to use.
+
+	  Valid options are "stable" or a Google Cloud Storage link to a build.
+
+config phase2.kubelet_version
+	string "kubelet version"
+	default "stable"
+	help
+	  The version of kubelet to use.
 
 	  Valid options are "stable" or a Google Cloud Storage link to a build.
 


### PR DESCRIPTION
Prior to this change, the kubelet on the master and nodes would always be at the same version as kubeadm. Breaking the version of the kubelet away from the version of kubeadm gives the flexibility of starting up consistent clusters that are at an older version than the kubeadm binary.

This helps with e2e testing issues: https://github.com/kubernetes/kubeadm/issues/431

Configuration could be updated to reflect their purpose a bit better eg. kubernetes_version really is the control plane version. Such naming changes are outside the scope of this pull request to focus efforts on fixing things.