### PR TITLE
Handle a kubeadm gs version with a trailing slash by trimming the slash.

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -41,9 +41,10 @@ if [[ "${KUBEADM_VERSION}" != "${KUBELET_VERSION}" ]]; then
     echo "Kubeadm version of 'stable' is not supported with kubelet version that is not also 'stable'."
     exit 1
   elif [[ "${KUBEADM_VERSION}" == "gs://"* ]]; then
+    KUBEADM_DIR=${KUBEADM_VERSION%/}
     TMPDIR=/tmp/k8s-debs
     mkdir $TMPDIR
-    gsutil cp "${KUBEADM_VERSION}/kubeadm" $TMPDIR/kubeadm
+    gsutil cp "${KUBEADM_DIR}/kubeadm" $TMPDIR/kubeadm
     cp $TMPDIR/kubeadm /usr/bin/kubeadm
     rm -rf $TMPDIR
   else

--- a/phase2/kubeadm/do
+++ b/phase2/kubeadm/do
@@ -38,9 +38,10 @@ update_host_kubeadm() {
     STABLE_VERSION=$(curl -sSL dl.k8s.io/release/stable.txt)
     execute_host ${HOST} "sudo curl -sSL dl.k8s.io/release/${STABLE_VERSION}/bin/linux/amd64/kubeadm | sudo tee /usr/bin/kubeadm 1> /dev/null" 
   elif [[ "${KUBEADM_VERSION}" == "gs://"* ]]; then
+    KUBEADM_DIR=${KUBEADM_VERSION%/}
     TMPDIR=/tmp/k8s-debs
     execute_host ${HOST} "sudo mkdir ${TMPDIR}"
-    execute_host ${HOST} "sudo gsutil cp "${KUBEADM_VERSION}/kubeadm" ${TMPDIR}/kubeadm"
+    execute_host ${HOST} "sudo gsutil cp "${KUBEADM_DIR}/kubeadm" ${TMPDIR}/kubeadm"
     execute_host ${HOST} "sudo cp ${TMPDIR}/kubeadm /usr/bin/kubeadm"
     execute_host ${HOST} "sudo rm -rf ${TMPDIR}"
   else


### PR DESCRIPTION
If a kubeadm gs version is provided with a backslash, the gsutil cp command will try and fail to pull a file path with a double backslash (ie. gs util gs://kubernetes-release-dev/bazel/v1.8.0-beta.1/bin/linux/amd64//kubeadm). Trim trailing backslashes on kubeadm gs versions to handle this problem.