### PR TITLE
Fix for vSphere password and make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ docker-push: docker-build
 	docker push $(IMAGE_NAME):$(IMAGE_VERSION)
 
 clean:
-	( if [[ -e "${CONFIG_JSON_FILE}" ]];then rm -rf phase3/${CLOUD_PROVIDER}/.tmp/ phase1/${CLOUD_PROVIDER}/${CLUSTER_NAME}/; fi )
+	(if [[ ! -z "${CLOUD_PROVIDER}" && ! -z "${CLUSTER_NAME}" ]];then rm -rf phase3/${CLOUD_PROVIDER}/.tmp/ phase1/${CLOUD_PROVIDER}/${CLUSTER_NAME}/; fi)
 
 fmt:
 	for f in $$(find . -name '*.jsonnet'); do jsonnet fmt -i -n 2 $${f}; done;

--- a/phase1/vsphere/vSphere.jsonnet
+++ b/phase1/vsphere/vSphere.jsonnet
@@ -15,13 +15,12 @@ function(config)
         "https://${vsphere_virtual_machine.kubevm1.network_interface.0.ipv4_address}",
       ));
 
-  local config_metadata_template = std.toString(config {
+  local config_metadata_template = config {
       master_ip: "${vsphere_virtual_machine.kubevm1.network_interface.0.ipv4_address}",
-      role: "%s",
       phase3 +: {
         addons_config: (import "phase3/all.jsonnet")(config),
       },
-    });
+    };
   
   std.mergePatch({
     // vSphere Configuration
@@ -135,7 +134,7 @@ function(config)
                 "remote-exec": {
                   inline: [
                     "hostnamectl set-hostname %s" % std.join("", [cfg.cluster_name, "-master"]),
-                    "mkdir -p /etc/kubernetes/; echo '%s' > /etc/kubernetes/k8s_config.json " % (config_metadata_template % "master"),                    
+                    "mkdir -p /etc/kubernetes/; echo '%s' > /etc/kubernetes/k8s_config.json " % std.toString((config_metadata_template {role: "master"})),
                     "echo '%s' >  /etc/kubernetes/vsphere.conf" % "${data.template_file.cloudprovider.rendered}",            
                     "echo '%s' > /etc/configure-vm.sh; bash /etc/configure-vm.sh" % "${data.template_file.configure_master.rendered}",
                   ]
@@ -157,7 +156,7 @@ function(config)
                 "remote-exec": {
                   inline: [
                     "hostnamectl set-hostname %s" % std.join("", [cfg.cluster_name, "-node", vm-1]),
-                    "mkdir -p /etc/kubernetes/; echo '%s' > /etc/kubernetes/k8s_config.json " % (config_metadata_template % "node"),                    
+                    "mkdir -p /etc/kubernetes/; echo '%s' > /etc/kubernetes/k8s_config.json " % std.toString((config_metadata_template {role: "node"})),
                     "echo '%s' > /etc/configure-vm.sh; bash /etc/configure-vm.sh" % "${data.template_file.configure_node.rendered}",
                     "echo '%s' >  /etc/kubernetes/vsphere.conf" % "${data.template_file.cloudprovider.rendered}",            
                   ]


### PR DESCRIPTION
1. This PR fixes #370 i.e with this fix: kubernetes-anywhere will accept '%' char in password for vSphere.
2. Currently, if user executes ```make clean``` and config file doesn't exist then phase1 folder is deleted. This PR also fixes this issue.