### PR TITLE
add kube-proxy mode in kubeadm config file

### DIFF
--- a/phase1/gce/configure-vm.sh
+++ b/phase1/gce/configure-vm.sh
@@ -20,6 +20,7 @@ KUBEADM_ENABLE_CLOUD_PROVIDER=$(get_metadata "k8s-kubeadm-enable-cloud-provider"
 KUBEADM_ADVERTISE_ADDRESSES=$(get_metadata "k8s-kubeadm-advertise-addresses")
 KUBEADM_CNI_PLUGIN=$(get_metadata "k8s-kubeadm-cni-plugin")
 KUBEADM_MASTER_IP=$(get_metadata "k8s-kubeadm-master-ip")
+KUBEPROXY_MODE=$(get_metadata "k8s-kubeproxy-mode")
 
 CLOUD_PROVIDER="gce"
 

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -157,6 +157,7 @@ function(cfg)
             "k8s-kubeadm-cni-plugin": if std.objectHas(p3, "cni") then p3.cni else "",
           } + if p2.provider == "kubeadm" then {
             "k8s-kubeadm-token": "${var.kubeadm_token}",
+            "k8s-kubeproxy-mode": "%(proxy_mode)s" % p2,
             "k8s-kubeadm-version": "%(version)s" % p2.kubeadm,
             "k8s-kubeadm-kubernetes-version": "%(kubernetes_version)s" % p2,
             "k8s-kubeadm-kubelet-version": "%(kubelet_version)s" % p2,

--- a/phase1/openstack/configure-vm.sh
+++ b/phase1/openstack/configure-vm.sh
@@ -13,6 +13,7 @@ KUBEADM_ENABLE_CLOUD_PROVIDER="${k8s_kubeadm_enable_cloud_provider}"
 KUBEADM_ADVERTISE_ADDRESSES="${k8s_kubeadm_advertise_addresses}"
 KUBEADM_CNI_PLUGIN="${k8s_kubeadm_cni_plugin}"
 KUBEADM_MASTER_IP="${k8s_kubeadm_master_ip}"
+KUBEPROXY_MODE="${k8s_kubeproxy_mode}"
 
 CLOUD_PROVIDER="openstack"
 

--- a/phase1/openstack/openstack.jsonnet
+++ b/phase1/openstack/openstack.jsonnet
@@ -66,6 +66,7 @@ function(cfg)
         k8s_kubeadm_kubernetes_version: "%(kubernetes_version)s" % p2,
         k8s_kubeadm_advertise_addresses: "${openstack_compute_floatingip_v2.%(master_ip)s.address}" % names,
         k8s_kubeadm_token: "${var.kubeadm_token}",
+        k8s_kubeproxy_mode: "%(proxy_mode)s" % p2,
         k8s_kubeadm_cni_plugin: if std.objectHas(p3, "cni") then p3.cni else "",
         k8s_kubeadm_kubelet_version: "%(kubelet_version)s" % p2,
         k8s_kubeadm_enable_cloud_provider: (if std.objectHas(p2, "enable_cloud_provider") && p2.enable_cloud_provider then "true" else "false"),

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -21,6 +21,14 @@ config phase2.provider
 
 	  Valid options are (ignition, kubeadm).
 
+config phase2.proxy_mode
+	string "kube-proxy mode: iptables or ipvs"
+	default "iptables"
+	help
+	  The kube-proxy mode to use.
+
+	  Valid options are (iptables, ipvs).
+
 if phase2.provider = ignition
 
 config phase2.installer_container

--- a/phase2/kubeadm/configure-vm-kubeadm-master.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-master.sh
@@ -33,4 +33,14 @@ cloudProvider: "$CLOUD_PROVIDER"
 EOF
 fi
 
+
+if [[ "$KUBEPROXY_MODE" == "ipvs" ]]; then
+    cat <<EOF |tee -a $KUBEADM_CONFIG_FILE
+kubeProxy:
+  config:
+    featureGates: SupportIPVSProxyMode=true
+    mode: "$KUBEPROXY_MODE"
+EOF
+fi
+
 kubeadm init --skip-preflight-checks --config $KUBEADM_CONFIG_FILE


### PR DESCRIPTION
added kube-proxy mode in kubeadm config file, so that we can easily chose proxy mode when build cluster, espically if we want use ipvs mode. 
Already added kube-proxy-mode args in kubeadm, in [this pr](https://github.com/kubernetes/kubernetes/pull/53962) : https://github.com/kubernetes/kubernetes/pull/53962
