### PR TITLE
Fix a syntax error in startup script

### DIFF
--- a/phase1/gce/configure-vm-kubeadm.sh
+++ b/phase1/gce/configure-vm-kubeadm.sh
@@ -74,7 +74,7 @@ case "${ROLE}" in
     # and use the configured value by passing it on to CNI's. We resort to the below hard-coding
     # since the current CNI's are not enabled to be configured with the user provided pod-network-cidr.
     POD_NETWORK_CIDR=""
-    if [[ "${CNI}" == "flannel" ] || [ "${CNI}" == "calico" ]]; then
+    if [[ "${CNI}" == "flannel" ]] || [[ "${CNI}" == "calico" ]]; then
       POD_NETWORK_CIDR="10.244.0.0/16"
     elif [[ "${CNI}" == "weave" ]]; then
       POD_NETWORK_CIDR="10.32.0.0/12"


### PR DESCRIPTION
There seems to be an error introduced recently in the startup script which produces below error
```
-bash: syntax error in conditional expression
-bash: syntax error near `]'
```

/cc @cmluciano 
/assign @pipejakob 
