### PR TITLE
Add --discovery-token-unsafe-skip-ca-verification to prevent kubeadm …

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm-node.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-node.sh
@@ -1,4 +1,4 @@
 
 # This is not meant to run on its own, but extends phase2/kubeadm/configure-vm-kubeadm.sh
 
-kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks
+kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks --discovery-token-unsafe-skip-ca-verification


### PR DESCRIPTION
…join failure

Since https://github.com/kubernetes/kubernetes/pull/55468 merged, kubeadm now requires the user to specify either the `--discovery-token-ca-cert-hash` flag or the `--discovery-token-unsafe-skip-ca-verification` flag