### PR TITLE
add featuregate opt for kubeadm

### DIFF
--- a/phase1/gce/configure-vm.sh
+++ b/phase1/gce/configure-vm.sh
@@ -21,6 +21,7 @@ KUBEADM_ADVERTISE_ADDRESSES=$(get_metadata "k8s-kubeadm-advertise-addresses")
 KUBEADM_CNI_PLUGIN=$(get_metadata "k8s-kubeadm-cni-plugin")
 KUBEADM_MASTER_IP=$(get_metadata "k8s-kubeadm-master-ip")
 KUBEPROXY_MODE=$(get_metadata "k8s-kubeproxy-mode")
+KUBEADM_FEATURE_GATES=$(get_metadata "k8s-kubeadm-feature-gates")
 
 CLOUD_PROVIDER="gce"
 

--- a/phase1/gce/gce.jsonnet
+++ b/phase1/gce/gce.jsonnet
@@ -157,11 +157,12 @@ function(cfg)
             "k8s-kubeadm-cni-plugin": if std.objectHas(p3, "cni") then p3.cni else "",
           } + if p2.provider == "kubeadm" then {
             "k8s-kubeadm-token": "${var.kubeadm_token}",
-            "k8s-kubeproxy-mode": "%(proxy_mode)s" % p2,
+            "k8s-kubeproxy-mode": if std.objectHas(p2, "proxy_mode") then "%(proxy_mode)s" % p2 else "",
             "k8s-kubeadm-version": "%(version)s" % p2.kubeadm,
             "k8s-kubeadm-kubernetes-version": "%(kubernetes_version)s" % p2,
             "k8s-kubeadm-kubelet-version": "%(kubelet_version)s" % p2,
             "k8s-kubeadm-enable-cloud-provider": (if std.objectHas(p2, "enable_cloud_provider") && p2.enable_cloud_provider then "true" else "false"),
+            "k8s-kubeadm-feature-gates": if std.objectHas(p2.kubeadm, "feature_gates") then "%(feature_gates)s" % p2.kubeadm else "",
           } else {
             "k8s-config": config_metadata_template % [names.master_ip, "master"],
             "k8s-ca-public-key": "${tls_self_signed_cert.%s-root.cert_pem}" % p1.cluster_name,

--- a/phase1/openstack/configure-vm.sh
+++ b/phase1/openstack/configure-vm.sh
@@ -14,6 +14,7 @@ KUBEADM_ADVERTISE_ADDRESSES="${k8s_kubeadm_advertise_addresses}"
 KUBEADM_CNI_PLUGIN="${k8s_kubeadm_cni_plugin}"
 KUBEADM_MASTER_IP="${k8s_kubeadm_master_ip}"
 KUBEPROXY_MODE="${k8s_kubeproxy_mode}"
+KUBEADM_FEATURE_GATES=${k8s_kubeadm_feature_gates}
 
 CLOUD_PROVIDER="openstack"
 

--- a/phase1/openstack/openstack.jsonnet
+++ b/phase1/openstack/openstack.jsonnet
@@ -71,6 +71,7 @@ function(cfg)
         k8s_kubeadm_kubelet_version: "%(kubelet_version)s" % p2,
         k8s_kubeadm_enable_cloud_provider: (if std.objectHas(p2, "enable_cloud_provider") && p2.enable_cloud_provider then "true" else "false"),
         k8s_kubeadm_master_ip: "",
+        k8s_kubeadm_feature_gates: if std.objectHas(p2.kubeadm, "feature_gates") then "%(feature_gates)s" % p2.kubeadm else "",
       },
       "template_file": {
         "master": {

--- a/phase2/Kconfig
+++ b/phase2/Kconfig
@@ -78,6 +78,16 @@ config phase2.enable_cloud_provider
 	help
 	  Should we enable and initialize cloud provider for the cluster?
 
+config phase2.kubeadm.feature_gates
+	string "kubeadm feature gates"
+	default ""
+	help
+	  Enable or disable specific features of kubeadm.
+
+	  Valid options are a set of key-value pairs in format : "<key-1>=<values-1>,<key-2>=<value-2>,.."
+	  as of today values must be booleans : true or false
+	  see "--feature-gates" option of kubeadm for description of keys.
+
 endif
 
 endmenu

--- a/phase2/kubeadm/configure-vm-kubeadm-master.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-master.sh
@@ -33,13 +33,28 @@ cloudProvider: "$CLOUD_PROVIDER"
 EOF
 fi
 
-
 if [[ "$KUBEPROXY_MODE" == "ipvs" ]]; then
     cat <<EOF |tee -a $KUBEADM_CONFIG_FILE
 kubeProxy:
   config:
     featureGates: SupportIPVSProxyMode=true
     mode: "$KUBEPROXY_MODE"
+EOF
+fi
+
+# if exist $KUBEADM_FEATURE_GATES is an string in format "key1=values1,key2=value2,.."
+# it should be added in the config in an YAML format for the field featureGates - eg:
+# featureGates:
+#   key1: value1
+#   key2: value2
+#   etc ...
+#NOTE: it is important to avoid the substituion and expression format for a variable. Therefore the usage of evaluated (echo + sed)
+KUBEADM_FEATURE_GATES=`echo "$KUBEADM_FEATURE_GATES" | sed -e 's/^[[:space:]]*//'`
+if [[ ! -z $KUBEADM_FEATURE_GATES ]]; then
+  foptions=`echo $KUBEADM_FEATURE_GATES | sed -e 's/=/: /g;s/,/\\\n  /g'`
+  cat <<EOF |tee -a $KUBEADM_CONFIG_FILE
+featureGates:
+  `echo -e "$foptions"`
 EOF
 fi
 


### PR DESCRIPTION
## What this PR does / why we need it:

allow option 'FeatureGates' when deploying kubeadm on the master's node of the cluster.
this option when set with "CoreDNS=true" allow to run CoreDNS as the default DNS server in the cluster instead of usual kube-dns

## Which issue this PR fixes 
Adds part of e2e integration requires for CoreDNS that is an ALPHA feature added to kubeadm 
See: kubernetes/kubeadm#446
it will need a second part in the project "test-infra"

## Special notes for your reviewer:
_In order to have the deployment of cluster run on GCE, I needed to fix issues on "terraform" tool usage (command line and config file). see gce/do and gce/gce.jsonnet_
**rollbacked in last commit. That was tied to the version of "terraform" used for testing.**
