### PR TITLE
Don't pass true for bool type flag --discovery-token-unsafe-skip-ca-verification

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm-node.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-node.sh
@@ -1,4 +1,4 @@
 
 # This is not meant to run on its own, but extends phase2/kubeadm/configure-vm-kubeadm.sh
 
-kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks --discovery-token-unsafe-skip-ca-verification true
+kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks --discovery-token-unsafe-skip-ca-verification


### PR DESCRIPTION
Passing the flag means `true`, right? Seems like `--discovery-token-unsafe-skip-ca-verification true` is invalid.

xref: https://github.com/kubernetes/kubernetes/issues/56091 `[job failure] kubeadm-gce`

```
Nov 23 05:13:24 ubuntu startupscript: kubeadm join --token "$KUBEADM_TOKEN" "$KUBEADM_MASTER_IP:443" --skip-preflight-checks --discovery-token-unsafe-skip-ca-verification true
Nov 23 05:13:24 ubuntu startupscript: + kubeadm join --token 043479.1a6ec0adafb593d0 10.128.0.2:443 --skip-preflight-checks --discovery-token-unsafe-skip-ca-verification true
Nov 23 05:13:25 ubuntu startupscript: Flag --skip-preflight-checks has been deprecated, it is now equivalent to --ignore-checks-errors=all
Nov 23 05:13:25 ubuntu startupscript: [kubeadm] WARNING: kubeadm is currently in beta
Nov 23 05:13:25 ubuntu startupscript: [preflight] Running pre-flight checks.
Nov 23 05:13:25 ubuntu startupscript: #011[WARNING FileExisting-crictl]: crictl not found in system path
Nov 23 05:13:25 ubuntu startupscript: [validation] WARNING: kubeadm doesn't fully support multiple API Servers yet
Nov 23 05:13:25 ubuntu startupscript: discovery: Invalid value: "true": address true: missing port in address
Nov 23 05:13:25 ubuntu startupscript: Finished running startup script /var/run/google.startup.script
```

@pipejakob @luxas @dims @spiffxp 