### PR TITLE
Add newline before IPVS featureGates config in startup

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm-master.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm-master.sh
@@ -37,7 +37,8 @@ if [[ "$KUBEPROXY_MODE" == "ipvs" ]]; then
     cat <<EOF |tee -a $KUBEADM_CONFIG_FILE
 kubeProxy:
   config:
-    featureGates: SupportIPVSProxyMode=true
+    featureGates:
+      SupportIPVSProxyMode: true
     mode: "$KUBEPROXY_MODE"
 EOF
 fi


### PR DESCRIPTION
The Kubernetes ci-kubernetes-e2e-kubeadm-gce-ipvs CI tests are failing (see [gubernator results](https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-ipvs) ) in the kubernetes-anywhere Phase 2.

The kube master serial logs show YAML decode errors for kubeadm config where either a '{' or newline is expected afer "featureGates:". The [kubeadm config file documentation](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/#config-file) indicates that the expected format for featureGates is:
```
featureGates:
  <feature>: <bool>
  <feature>: <bool>
```
Accordingly, the config in the startup script needs to be changed from:
```
    featureGates: SupportIPVSProxyMode=true
```
to:
```
    featureGates:
      SupportIPVSProxyMode: true
```

Fixes #527