### PR TITLE
kubeadm requires cri-tools

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm.sh
@@ -63,7 +63,7 @@ elif [[ "$KUBEADM_KUBELET_VERSION" == "gs://"* ]]; then
   # TODO: Remove the following mkdir when bazelbuild/bazel
   # issue #4651 gets resolved.
   mkdir -p /opt/cni/bin
-  dpkg -i $TMPDIR/{kubelet,kubeadm,kubectl,kubernetes-cni}.deb || echo Ignoring expected dpkg failure
+  dpkg -i $TMPDIR/{kubelet,kubeadm,kubectl,kubernetes-cni,cri-tools}.deb || echo Ignoring expected dpkg failure
   apt-get install -f -y
   systemctl enable kubelet
   systemctl start kubelet


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-cni-flannel/3157/artifacts/e2e-3157-098af-master/serial-1.log

INFO startup-script:  kubeadm depends on cri-tools (>= 1.11.0); however:
INFO startup-script:   Package cri-tools is not installed.
INFO startup-script: dpkg: error processing package kubeadm (--install):
INFO startup-script: Removing kubeadm (1.12.0~alpha.0.1584+aa06ec6dd3a010) ...
...
INFO startup-script: kubeadm init --skip-preflight-checks --config $KUBEADM_CONFIG_FILE
INFO startup-script: + kubeadm init --skip-preflight-checks --config /etc/kubeadm/kubeadm.yaml
INFO startup-script: /startup-wsmbtznt/tmpjucy96_3: line 211: kubeadm: command not found
INFO startup-script: Return code 127.
INFO Finished running startup scripts.

@thockin @caseydavenport @leblancd this is the only thing I can think of that's blocking some of the kubeadm-gce tests.