### PR TITLE
[WIP] phase2: fix kubeadm install issues

### DIFF
--- a/phase2/kubeadm/configure-vm-kubeadm.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm.sh
@@ -53,7 +53,7 @@ EOF
   apt-get update
   # kubeadm is installed with the kubelet so that the
   # kubelet has the configuration at a matching version
-  apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+  apt-get install -y cri-tools kubelet kubeadm kubectl kubernetes-cni
 elif [[ "$KUBEADM_KUBELET_VERSION" == "gs://"* ]]; then
   TMPDIR=/tmp/k8s-debs
   mkdir $TMPDIR
@@ -63,7 +63,7 @@ elif [[ "$KUBEADM_KUBELET_VERSION" == "gs://"* ]]; then
   # TODO: Remove the following mkdir when bazelbuild/bazel
   # issue #4651 gets resolved.
   mkdir -p /opt/cni/bin
-  dpkg -i $TMPDIR/{kubelet,kubeadm,kubectl,kubernetes-cni,cri-tools}.deb || echo Ignoring expected dpkg failure
+  dpkg -i $TMPDIR/{cri-tools,kubelet,kubeadm,kubectl,kubernetes-cni}.deb || echo Ignoring expected dpkg failure
   apt-get install -f -y
   systemctl enable kubelet
   systemctl start kubelet


### PR DESCRIPTION
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce/10938/artifacts/e2e-10938-31d72-master/serial-1.log

refs kubernetes/kubernetes#66338

there is a dependency weirdness here that i don't understand:

kubeadm is not installed, even if the cri-tools and the kubelet are installed.
this is a WIP PR to gather feedback.

```
Jun 22 13:04:02 e2e-10938-31d72-master startup-script: INFO startup-script: Selecting previously unselected package kubectl.
Jun 22 13:04:02 e2e-10938-31d72-master startup-script: INFO startup-script: Preparing to unpack /tmp/k8s-debs/kubectl.deb ...
Jun 22 13:04:02 e2e-10938-31d72-master startup-script: INFO startup-script: Unpacking kubectl (1.12.0~alpha.0.1408+1ca851baec6a24) ...
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: Selecting previously unselected package kubernetes-cni.
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: Preparing to unpack .../k8s-debs/kubernetes-cni.deb ...
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: Unpacking kubernetes-cni (0.5.1) ...
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: dpkg: dependency problems prevent configuration of kubelet:
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:  kubelet depends on socat; however:
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:   Package socat is not installed.
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:  kubelet depends on ebtables; however:
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:   Package ebtables is not installed.
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: dpkg: error processing package kubelet (--install):
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:  dependency problems - leaving unconfigured
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: dpkg: dependency problems prevent configuration of kubeadm:
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:  kubeadm depends on kubelet (>= 1.8.0); however:
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:   Package kubelet is not configured yet.
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:  kubeadm depends on cri-tools (>= 1.11.0); however:
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:   Package cri-tools is not installed.
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: dpkg: error processing package kubeadm (--install):
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:  dependency problems - leaving unconfigured
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: Setting up kubectl (1.12.0~alpha.0.1408+1ca851baec6a24) ...
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: Setting up kubernetes-cni (0.5.1) ...
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script: Errors were encountered while processing:
Jun 22 13:04:03 e2e-10938-31d72-master startup-script: INFO startup-script:  kubelet
```

please advise on how to fix this correctly.

@timothysc @dims @BenTheElder 
