### PR TITLE
update OWNERS file for branch kubeadm-e2e

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,8 @@ reviewers:
   - mikedanese
   - monadic
   - pipejakob
+  - fabriziopandini
+  - neolit123
 approvers:
   - abrarshivani
   - colemickens
@@ -18,3 +20,5 @@ approvers:
   - mikedanese
   - monadic
   - pipejakob
+  - fabriziopandini
+  - neolit123


### PR DESCRIPTION
add me and @fabriziopandini to the OWNER files for this branch.

the repo now has `/lgtm` and `/approve` commands enabled and we should use them:
https://github.com/kubernetes/kubernetes-anywhere/issues/563
