### PR TITLE
apply a set of patches to build scripts and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(CONFIG_JSON_FILE): $(CONFIG_FILE_ABS)
 echo-config: $(CONFIG_JSON_FILE)
 	cat $<
 
-deploy-cluster destroy-cluster: $(CONFIG_JSON_FILE)
+deploy-cluster destroy-cluster: echo-config
 	$(MAKE) do WHAT=$@
 
 upgrade-master: $(CONFIG_JSON_FILE)

--- a/phase1/gce/do
+++ b/phase1/gce/do
@@ -69,6 +69,14 @@ fetch_kubeconfig() {
       sed '/^STARTFILE$/,$!d;/^STARTFILE$/d' ${TMP_DIR}/kubeconfig.raw > ${CLUSTER_DIR}/kubeconfig.json
       echo Successfully fetched kubeconfig.
 
+      echo "kubeconfig contents:"
+      cat ${CLUSTER_DIR}/kubeconfig.json
+
+      if [ ! -s "${CLUSTER_DIR}/kubeconfig.json" ]; then \
+        echo "ERROR: the kubeconfig file is empty!" > /dev/stderr; \
+        exit 1
+      fi
+
       if [[ -n "${KUBE_CONTEXT_NAME}" ]]; then
         # kubeconfig.json fetched from master node has the user, cluster and context all hardcoded with
         # 'kubernetes' keyword. So replace 'kubernetes' with the cluster_name.

--- a/phase2/kubeadm/configure-vm-kubeadm.sh
+++ b/phase2/kubeadm/configure-vm-kubeadm.sh
@@ -52,8 +52,10 @@ if [[ "$KUBEADM_KUBELET_VERSION" == stable ]]; then
 EOF
   apt-get update
   # kubeadm is installed with the kubelet so that the
-  # kubelet has the configuration at a matching version
-  apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+  # kubelet has the configuration at a matching version.
+  # STABLE is used so that no pre-release packages are picked up
+  STABLE=$(apt-cache madison kubelet | awk '{print $3}' | grep '^[^a-zA-Z]*$' -m 1)
+  apt-get install -y kubelet=$STABLE kubeadm=$STABLE kubectl=$STABLE kubernetes-cni
 elif [[ "$KUBEADM_KUBELET_VERSION" == "gs://"* ]]; then
   TMPDIR=/tmp/k8s-debs
   mkdir $TMPDIR


### PR DESCRIPTION
from the discussion on slack:
> echo the .config.json at the beginning of the build-log.txt, it will be simpler to reproduce the failing case.

the second commit adds ac check if the kubeconfig is emtpy....
for some reason `gcloud ssh` gets it like that and i have no idea why.
at least that's some indication of something being wrong with the config.

third change is to ignore pre-release packages for `stable` kubelet.

/kind cleanup
/assign @fabriziopandini 
