### PR TITLE
phase2: exclude the 'config upload' step for upgrades

### DIFF
--- a/phase2/kubeadm/do
+++ b/phase2/kubeadm/do
@@ -25,7 +25,6 @@ upgrade_master() {
       execute_host ${MASTER} "sudo kubeadm init --ignore-preflight-errors=all --config ${KUBEADM_CONFIG_FILE}"
       ;;
     "upgrade")
-      execute_host ${MASTER} "sudo kubeadm config upload from-file --config ${KUBEADM_CONFIG_FILE}"
       execute_host ${MASTER} "sudo kubeadm upgrade apply ${KUBERNETES_VERSION} -y -f"
       ;;
   esac


### PR DESCRIPTION
@fabriziopandini as promised, but i haven't experimented if this fixes it.
do we have to still include this for 1.11?