### PR TITLE
phase1: bump docker version to 1.13.1

### DIFF
--- a/phase1/gce/configure-vm.sh
+++ b/phase1/gce/configure-vm.sh
@@ -40,6 +40,7 @@ EOF
 
 apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys F76221572C52609D
 apt-get update
-apt-get install -y docker-engine=1.12.0-0~xenial
+sudo apt-cache policy docker-engine
+sudo apt-get -y install docker-engine=1.13.1-0~ubuntu-xenial
 systemctl enable docker || true
 systemctl start docker || true


### PR DESCRIPTION
this PR bumped the minimum docker version in the kubelet and turned our e2e tests red:
https://github.com/kubernetes/kubernetes/pull/72831
https://gubernator.k8s.io/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-gce-master/1519

i have tested the change in a xenial container.

/assign @fabriziopandini 
/cc @timothysc @mauilion
